### PR TITLE
Refactor background color logic

### DIFF
--- a/Data/ResultService.cs
+++ b/Data/ResultService.cs
@@ -143,26 +143,6 @@ namespace CompetitionResults.Data
             }
         }
 
-        private void AssignBackgroundColors(List<ResultDto> results)
-        {
-            foreach (var r in results)
-            {
-                if (r.IsTieForMedal)
-                {
-                    r.BackgroundColor = "background-color: red;";
-                }
-                else
-                {
-                    r.BackgroundColor = r.Position switch
-                    {
-                        1 => "background-color: gold;",
-                        2 => "background-color: silver;",
-                        3 => "background-color: #CD7F32;",
-                        _ => string.Empty
-                    };
-                }
-            }
-        }
 
 
 
@@ -196,7 +176,6 @@ namespace CompetitionResults.Data
             AssignPointsAwards(results, results.Count);
             AssignPositions(results, discipline.IsDividedToCategories, isReverseOrdered);
             MarkTiesForMedals(results, discipline.IsDividedToCategories);
-            AssignBackgroundColors(results);
 
             return results;
         }
@@ -269,8 +248,6 @@ namespace CompetitionResults.Data
             {
                 resultList[i].Position = i + 1;
             }
-
-            AssignBackgroundColors(resultList);
 
             return resultList;
         }
@@ -535,18 +512,41 @@ namespace CompetitionResults.Data
 		}
 	}
 
-	public class ResultDto
-	{
-        public int ThrowerId { get; set; }
-		public string ThrowerName { get; set; }
-        public int Position { get; set; }
-		public double? Points { get; set; }
-        public int? BullseyeCount { get; set; }
-        public double? PointsAward { get; set; }
-        public bool IsTieForMedal { get; set; } // použito v UI k zobrazení červeného pozadí
-        public int CategoryId { get; set; }
-        public int DisciplineId { get; set; } // přidáno pro snadné filtrování
-        public string BackgroundColor { get; set; }
+        public class ResultDto
+        {
+            public int ThrowerId { get; set; }
+            public string ThrowerName { get; set; }
+            public int Position { get; set; }
+            public double? Points { get; set; }
+            public int? BullseyeCount { get; set; }
+            public double? PointsAward { get; set; }
+            public bool IsTieForMedal { get; set; } // použito v UI k zobrazení červeného pozadí
+            public int CategoryId { get; set; }
+            public int DisciplineId { get; set; } // přidáno pro snadné filtrování
+
+            public string BackgroundColor
+            {
+                get
+                {
+                    if (!Points.HasValue)
+                    {
+                        return "background-color: rgba(255,0,0,0.1);";
+                    }
+
+                    if (IsTieForMedal)
+                    {
+                        return "background-color: red;";
+                    }
+
+                    return Position switch
+                    {
+                        1 => "background-color: gold;",
+                        2 => "background-color: silver;",
+                        3 => "background-color: #CD7F32;",
+                        _ => string.Empty
+                    };
+                }
+            }
         }
 
 }

--- a/Pages/ResultsListStatic.razor
+++ b/Pages/ResultsListStatic.razor
@@ -51,13 +51,10 @@
 												{
 													var result = resultsDictionary[(category.Id, discipline.Id)].ElementAtOrDefault(i);
 													var resultValue = result?.Points;
-													var awardValue = result?.PointsAward;
-													var bulls = result?.BullseyeCount;
-													var isTie = result?.IsTieForMedal ?? false;
-
-													var backgroundColor = resultValue.HasValue
-														? (isTie ? "background-color: red;" : "")
-														: "background-color: rgba(255, 0, 0, 0.1);";
+            var awardValue = result?.PointsAward;
+            var bulls = result?.BullseyeCount;
+            var backgroundColor = result?.BackgroundColor ??
+                "background-color: rgba(255, 0, 0, 0.1);";
 
 													<td class="results-td" style="@backgroundColor">
 														<div class="cell">
@@ -114,13 +111,12 @@
 
 										@foreach (var discipline in disciplines.Where(d => !d.IsDividedToCategories).OrderBy(d => d.HasPositionsInsteadPoints).ThenBy(d => d.Id).Take(6))
 										{
-											var resultValue = GetResultValueForDisciplineOverall(discipline.Id, i);
-											var awardValue = GetAwardValueForDisciplineOverall(discipline.Id, i);
-											var isTie = GetIsTieForDisciplineOverall(discipline.Id, i);
-											var bulls = GetBullsForDisciplineOverall(discipline.Id, i);
-											var backgroundColor = resultValue.HasValue
-														? (isTie ? "background-color: red;" : "")
-														: "background-color: rgba(255, 0, 0, 0.1);";
+            var resultValue = GetResultValueForDisciplineOverall(discipline.Id, i);
+            var awardValue = GetAwardValueForDisciplineOverall(discipline.Id, i);
+            var bulls = GetBullsForDisciplineOverall(discipline.Id, i);
+            var resultEntry = resultsOverallDictionary[discipline.Id].ElementAtOrDefault(i);
+            var backgroundColor = resultEntry?.BackgroundColor ??
+                "background-color: rgba(255, 0, 0, 0.1);";
 
 											<td class="results-td" style="@backgroundColor">
 												<div class="cell">
@@ -168,13 +164,12 @@
 
 										@foreach (var discipline in disciplines.Where(d => !d.IsDividedToCategories).OrderBy(d => d.HasPositionsInsteadPoints).ThenBy(d => d.Id).Skip(6))
 										{
-											var resultValue = GetResultValueForDisciplineOverall(discipline.Id, i);
-											var awardValue = GetAwardValueForDisciplineOverall(discipline.Id, i);
-											var isTie = GetIsTieForDisciplineOverall(discipline.Id, i);
-											var bulls = GetBullsForDisciplineOverall(discipline.Id, i);
-											var backgroundColor = resultValue.HasValue
-														? (isTie ? "background-color: red;" : "")
-														: "background-color: rgba(255, 0, 0, 0.1);";
+            var resultValue = GetResultValueForDisciplineOverall(discipline.Id, i);
+            var awardValue = GetAwardValueForDisciplineOverall(discipline.Id, i);
+            var bulls = GetBullsForDisciplineOverall(discipline.Id, i);
+            var resultEntry = resultsOverallDictionary[discipline.Id].ElementAtOrDefault(i);
+            var backgroundColor = resultEntry?.BackgroundColor ??
+                "background-color: rgba(255, 0, 0, 0.1);";
 
 											<td class="results-td" style="@backgroundColor">
 												<div class="cell">

--- a/Pages/ResultsSelectable.razor
+++ b/Pages/ResultsSelectable.razor
@@ -105,11 +105,10 @@
 											var results = resultsByGroupedSelection[key];
 											var result = results.ElementAtOrDefault(i);
 											var name = result?.ThrowerName ?? "—";
-											var points = result?.Points;
-											var award = result?.PointsAward;
-											var bulls = result?.BullseyeCount;
-											var isTie = result?.IsTieForMedal ?? false;
-											var background = points.HasValue ? (isTie ? "background-color: red;" : "") : "background-color: rgba(255,0,0,0.1);";
+            var points = result?.Points;
+            var award = result?.PointsAward;
+            var bulls = result?.BullseyeCount;
+            var background = result?.BackgroundColor ?? "background-color: rgba(255,0,0,0.1);";
 
 											<td class="results-td" style="@background">
 												<div class="cell">
@@ -128,10 +127,9 @@
 												var result = results.ElementAtOrDefault(i);
 												var name = result?.ThrowerName ?? "—";
 												var points = result?.Points;
-												var award = result?.PointsAward;
-												var bulls = result?.BullseyeCount;
-												var isTie = result?.IsTieForMedal ?? false;
-												var background = points.HasValue ? (isTie ? "background-color: red;" : "") : "background-color: rgba(255,0,0,0.1);";
+            var award = result?.PointsAward;
+            var bulls = result?.BullseyeCount;
+            var background = result?.BackgroundColor ?? "background-color: rgba(255,0,0,0.1);";
 
 												<td class="results-td" style="@background">
 													<div class="cell">


### PR DESCRIPTION
## Summary
- compute row background color directly in `ResultDto`
- remove `AssignBackgroundColors` helper
- simplify pages to use the new `BackgroundColor` property

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d540ba77c832ca862681238819cbe