### PR TITLE
Add dialog for sending custom general emails

### DIFF
--- a/CompetitionResults/Components/Pages/ThrowersList.razor
+++ b/CompetitionResults/Components/Pages/ThrowersList.razor
@@ -13,7 +13,9 @@
 
 		<button @onclick="AddNew">Add New Thrower</button>
 		@* <button @onclick="SendEmailsToUnpaid">Send Emails to Unpaid Throwers</button> *@
-		<button @onclick="SendEmails">Send Emails to Hungry Throwers</button>
+                <button @onclick="OpenGeneralEmailModal">Send Emails to Hungry Throwers</button>
+
+                <GeneralEmailModal @ref="generalEmailModal" OnSend="HandleSendGeneralEmails" />
 
 		<ThrowerEditModal @ref="throwerEditModal" OnClose="HandleModalClose" Thrower="selectedThrower" OnFormSubmit="HandleFormSubmit" />
 
@@ -155,7 +157,8 @@
 </AuthorizeView>
 
 @code {
-	private ThrowerEditModal throwerEditModal;
+        private ThrowerEditModal throwerEditModal;
+        private GeneralEmailModal generalEmailModal;
 	private List<Thrower> throwers;
 	private Thrower selectedThrower = new Thrower();
 
@@ -276,26 +279,26 @@
 		}
 	}
 
-	private async Task SendEmails()
-	{
-		var allThrowers = throwers.ToList();
-		if (allThrowers.Any())
-		{
-			var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send emails to {allThrowers.Count} throwers?");
-			if (confirmed)
-			{
-				foreach (var thrower in allThrowers)
-				{
-					ThrowerService.SendGeneralEmail(thrower);
-				}
-				await JSRuntime.InvokeVoidAsync("alert", "Emails sent to throwers.");
-			}
-		}
-		else
-		{
-			await JSRuntime.InvokeVoidAsync("alert", "No throwers to send emails to.");
-		}
-	}
+        private async Task SendEmails(string localMessage, string englishMessage)
+        {
+                var allThrowers = throwers.ToList();
+                if (allThrowers.Any())
+                {
+                        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send emails to {allThrowers.Count} throwers?");
+                        if (confirmed)
+                        {
+                                foreach (var thrower in allThrowers)
+                                {
+                                        ThrowerService.SendGeneralEmail(thrower, localMessage, englishMessage);
+                                }
+                                await JSRuntime.InvokeVoidAsync("alert", "Emails sent to throwers.");
+                        }
+                }
+                else
+                {
+                        await JSRuntime.InvokeVoidAsync("alert", "No throwers to send emails to.");
+                }
+        }
 
 	private async Task DeleteThrower(int id)
 	{
@@ -341,9 +344,19 @@
 		LoadData();
 	}
 
-	private async Task HandleModalClose()
-	{
-		LoadData();
-	}
+        private async Task HandleModalClose()
+        {
+                LoadData();
+        }
+
+        private void OpenGeneralEmailModal()
+        {
+                generalEmailModal.Open();
+        }
+
+        private async Task HandleSendGeneralEmails(GeneralEmailModal.GeneralEmailContent content)
+        {
+                await SendEmails(content.LocalMessage, content.EnglishMessage);
+        }
 }
 

--- a/CompetitionResults/Components/Shared/GeneralEmailModal.razor
+++ b/CompetitionResults/Components/Shared/GeneralEmailModal.razor
@@ -1,0 +1,64 @@
+@using Microsoft.AspNetCore.Components
+<div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Send Email</h5>
+                <button type="button" class="btn-close" @onclick="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label>Local message:</label>
+                    <InputTextArea class="form-control" @bind-Value="content.LocalMessage" />
+                </div>
+                <div class="mb-3">
+                    <label>English message:</label>
+                    <InputTextArea class="form-control" @bind-Value="content.EnglishMessage" />
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" @onclick="Close">Cancel</button>
+                <button type="button" class="btn btn-primary" @onclick="Send">Send</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    public class GeneralEmailContent
+    {
+        public string LocalMessage { get; set; }
+        public string EnglishMessage { get; set; }
+    }
+
+    public bool IsOpen { get; private set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    [Parameter] public EventCallback<GeneralEmailContent> OnSend { get; set; }
+
+    private GeneralEmailContent content = new GeneralEmailContent();
+
+    public void Open()
+    {
+        content = new GeneralEmailContent();
+        IsOpen = true;
+        StateHasChanged();
+    }
+
+    private async Task Send()
+    {
+        if (OnSend.HasDelegate)
+        {
+            await OnSend.InvokeAsync(content);
+        }
+        await Close();
+    }
+
+    private async Task Close()
+    {
+        IsOpen = false;
+        if (OnClose.HasDelegate)
+        {
+            await OnClose.InvokeAsync();
+        }
+    }
+}

--- a/CompetitionResults/Data/ThrowerService.cs
+++ b/CompetitionResults/Data/ThrowerService.cs
@@ -105,28 +105,22 @@ namespace CompetitionResults.Data
             }
         }
 
-        public void SendGeneralEmail(Thrower thrower)
+        public void SendGeneralEmail(Thrower thrower, string localMessage, string englishMessage)
         {
             if (thrower.Email != null && !thrower.DoNotSendRegistrationEmail)
             {
                 string email;
                 string subject;
 
-                if (thrower.Nationality.ToUpper() == "CZ")
+                if (!string.IsNullOrEmpty(thrower.Nationality) && thrower.Nationality.ToUpper() == "CZ")
                 {
-                    subject = "Aktualizace cateringu";
-
-                    email = "Vážení účastníci,\n\n";
-
-                    email += "S pozdravem,\nTým UKAT World Cup";
+                    subject = "Obecná zpráva";
+                    email = localMessage;
                 }
                 else
                 {
-                    subject = "Catering Update";
-
-                    email = "Dear participants,\n\n";
-
-                    email += "Warm regards,\nUKAT World Cup Organizing Team";
+                    subject = "General Announcement";
+                    email = englishMessage;
                 }
 
                 SendEmail(thrower.Email, subject, email);


### PR DESCRIPTION
## Summary
- add `GeneralEmailModal` component for entering Local and English messages
- allow `ThrowerService.SendGeneralEmail` to accept custom messages per language
- use new dialog on `ThrowersList` page and send messages accordingly
- rename Czech fields to Local for better internationalization

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb618632c832cb6465b4be7a01c31