### PR TITLE
Add translation editing page

### DIFF
--- a/CompetitionResults.Tests/InMemoryDbFixture.cs
+++ b/CompetitionResults.Tests/InMemoryDbFixture.cs
@@ -13,6 +13,7 @@ public class InMemoryDbFixture : IDisposable
     public DisciplineService DisciplineService { get; }
     public CompetitionService CompetitionService { get; }
     public ThrowerService ThrowerService { get; }
+    public TranslationService TranslationService { get; }
 
     public InMemoryDbFixture()
     {
@@ -26,14 +27,19 @@ public class InMemoryDbFixture : IDisposable
         Context.Disciplines.AddRange(SeedData.Disciplines);
         Context.Throwers.AddRange(SeedData.Throwers);
         Context.Results.AddRange(SeedData.Results);
+        Context.Translations.AddRange(new[]
+        {
+            new Translation { Id = 1, Key = "Camping on site", Value = "Kempování na místě" }
+        });
         Context.SaveChanges();
 
         var notificationHub = new NotificationHub(null!);
+        TranslationService = new TranslationService(Context);
         ResultService = new ResultService(Context, notificationHub);
         CategoryService = new CategoryService(Context);
         DisciplineService = new DisciplineService(Context);
         CompetitionService = new CompetitionService(Context);
-        ThrowerService = new ThrowerService(Context, notificationHub, new ConfigurationBuilder().Build());
+        ThrowerService = new ThrowerService(Context, notificationHub, new ConfigurationBuilder().Build(), TranslationService);
     }
 
     public void Dispose()

--- a/CompetitionResults/CompetitionDbContext.cs
+++ b/CompetitionResults/CompetitionDbContext.cs
@@ -12,6 +12,7 @@
         public DbSet<Category> Categories { get; set; }
         public DbSet<Discipline> Disciplines { get; set; }
         public DbSet<Results> Results { get; set; }
+        public DbSet<Translation> Translations { get; set; }
 
         public CompetitionDbContext(DbContextOptions<CompetitionDbContext> options)
             : base(options)
@@ -97,6 +98,24 @@
 
             modelBuilder.Entity<Thrower>().HasData(
                 new Thrower { Id = 1, Name = "Zuzana", Surname = "Koreňová", Nickname = "Suzanne KO", Nationality = "CZ", CompetitionId = 1, CategoryId = 2, StartingNumber = 1 }
+            );
+
+            modelBuilder.Entity<Translation>().HasData(
+                new Translation { Id = 1, Key = "Camping on site", Value = "Kempování na místě" },
+                new Translation { Id = 2, Key = "Want T-Shirt", Value = "Chci tričko" },
+                new Translation { Id = 3, Key = "T-Shirt Size", Value = "Velikost trička" },
+                new Translation { Id = 4, Key = "Registration for competition", Value = "Registrace do závodu" },
+                new Translation { Id = 5, Key = "General Announcement", Value = "Obecná zpráva" },
+                new Translation { Id = 6, Key = "Important - Payment for competition", Value = "Dulezite - Platba za registraci" },
+                new Translation { Id = 7, Key = "You have been successfully registered to competition:", Value = "Byl/a jste úspěšně registrován/a na soutěž:" },
+                new Translation { Id = 8, Key = "Name", Value = "Jméno" },
+                new Translation { Id = 9, Key = "Surname", Value = "Příjmení" },
+                new Translation { Id = 10, Key = "Nickname", Value = "Přezdívka" },
+                new Translation { Id = 11, Key = "Nationality", Value = "Národnost" },
+                new Translation { Id = 12, Key = "Club name", Value = "Jméno klubu" },
+                new Translation { Id = 13, Key = "Email", Value = "Email" },
+                new Translation { Id = 14, Key = "Note", Value = "Poznámka" },
+                new Translation { Id = 15, Key = "Category", Value = "Kategorie" }
             );
         }
 

--- a/CompetitionResults/Components/Layout/NavMenu.razor
+++ b/CompetitionResults/Components/Layout/NavMenu.razor
@@ -40,12 +40,17 @@
 						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Categories
 					</NavLink>
 				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="disciplines">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="disciplines">
+                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
+                                        </NavLink>
+                                </div>
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="translations">
+                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Translations
+                                        </NavLink>
+                                </div>
+                                <div class="nav-item px-3">
 					<NavLink class="nav-link" href="throwers">
 						<span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Throwers
 					</NavLink>
@@ -79,16 +84,21 @@
 						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Categories
 					</NavLink>
 				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="disciplines">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="throwers">
-						<span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Throwers
-					</NavLink>
-				</div>
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="disciplines">
+                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
+                                        </NavLink>
+                                </div>
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="translations">
+                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Translations
+                                        </NavLink>
+                                </div>
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="throwers">
+                                                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Throwers
+                                        </NavLink>
+                                </div>
 				<div class="nav-item px-3">
 					<NavLink class="nav-link" href="scores">
 						<span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Scores

--- a/CompetitionResults/Components/Pages/ThrowersList.razor
+++ b/CompetitionResults/Components/Pages/ThrowersList.razor
@@ -252,14 +252,14 @@
 		}
 	}
 
-	private async Task SendUnpaidEmail(Thrower thrower)
-	{
-		var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send registration email to this thrower?");
-		if (confirmed)
-		{
-			ThrowerService.SendUnpaidEmail(thrower);
-		}
-	}
+        private async Task SendUnpaidEmail(Thrower thrower)
+        {
+            var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send registration email to this thrower?");
+            if (confirmed)
+            {
+                await ThrowerService.SendUnpaidEmail(thrower);
+            }
+        }
 
 	private async Task SendEmailsToUnpaid()
 	{
@@ -269,10 +269,10 @@
 			var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send emails to {unpaidThrowers.Count} unpaid throwers?");
 			if (confirmed)
 			{
-				foreach (var thrower in unpaidThrowers)
-				{
-					ThrowerService.SendUnpaidEmail(thrower);
-				}
+                                foreach (var thrower in unpaidThrowers)
+                                {
+                                        await ThrowerService.SendUnpaidEmail(thrower);
+                                }
 				await JSRuntime.InvokeVoidAsync("alert", "Emails sent to unpaid throwers.");
 			}
 		}

--- a/CompetitionResults/Components/Pages/TranslationsList.razor
+++ b/CompetitionResults/Components/Pages/TranslationsList.razor
@@ -1,0 +1,97 @@
+@page "/translations"
+@using CompetitionResults.Data
+@using CompetitionResults.Components.Shared
+@inject TranslationService TranslationService
+@inject IJSRuntime JSRuntime
+
+<h3>Translations</h3>
+
+<AuthorizeView Roles="Admin, Manager">
+    <Authorized>
+        <button @onclick="AddNew">Add New Translation</button>
+
+        <TranslationEditModal @ref="translationEditModal" OnClose="HandleModalClose" Translation="currentTranslation" OnFormSubmit="HandleFormSubmit" />
+
+        @if (translations == null)
+        {
+            <p><em>Loading...</em></p>
+        }
+        else
+        {
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var tr in translations)
+                    {
+                        <tr>
+                            <td>@tr.Key</td>
+                            <td>@tr.Value</td>
+                            <td>
+                                <button @onclick="() => EditTranslation(tr)">Edit</button>
+                                <button @onclick="() => DeleteTranslation(tr.Id)">Delete</button>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </Authorized>
+    <NotAuthorized>
+        <p>You're not loggged in.</p>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private TranslationEditModal translationEditModal;
+    private List<Translation> translations;
+    private Translation currentTranslation = new Translation();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+
+    private async Task LoadData()
+    {
+        translations = await TranslationService.GetAllTranslationsAsync();
+        StateHasChanged();
+    }
+
+    private void AddNew()
+    {
+        currentTranslation = new Translation();
+        translationEditModal.Open();
+    }
+
+    private void EditTranslation(Translation tr)
+    {
+        currentTranslation = tr;
+        translationEditModal.Open();
+    }
+
+    private async Task DeleteTranslation(int id)
+    {
+        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", "Are you sure you want to delete this translation?");
+        if (confirmed)
+        {
+            await TranslationService.DeleteTranslationAsync(id);
+            await LoadData();
+        }
+    }
+
+    private async Task HandleFormSubmit()
+    {
+        await LoadData();
+    }
+
+    private async Task HandleModalClose()
+    {
+        await LoadData();
+    }
+}

--- a/CompetitionResults/Components/Shared/TranslationEditModal.razor
+++ b/CompetitionResults/Components/Shared/TranslationEditModal.razor
@@ -1,0 +1,80 @@
+@using CompetitionResults.Data
+@inject TranslationService TranslationService
+
+<div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <EditForm Model="@_translation" OnValidSubmit="HandleValidSubmit">
+                <DataAnnotationsValidator />
+                <ValidationSummary />
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit Translation</h5>
+                    <button type="button" class="btn-close" @onclick="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-grid">
+                        <div>
+                            <label for="key">Key:</label>
+                            <InputText id="key" @bind-Value="@_translation.Key" />
+                        </div>
+                        <div>
+                            <label for="value">Value:</label>
+                            <InputText id="value" @bind-Value="@_translation.Value" />
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
+                    <button type="submit" class="btn btn-primary">Save changes</button>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+</div>
+
+@code {
+    public bool IsOpen { get; private set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    private Translation _translation;
+
+    protected override void OnInitialized()
+    {
+        _translation = new Translation();
+    }
+
+    [Parameter]
+    public Translation Translation
+    {
+        get => _translation;
+        set
+        {
+            if (_translation != value)
+            {
+                _translation = value;
+            }
+        }
+    }
+
+    [Parameter]
+    public EventCallback OnFormSubmit { get; set; }
+
+    private async Task HandleValidSubmit()
+    {
+        IsOpen = false;
+        await TranslationService.AddOrUpdateTranslationAsync(_translation);
+        await OnFormSubmit.InvokeAsync(null);
+    }
+
+    public void Open()
+    {
+        IsOpen = true;
+        StateHasChanged();
+    }
+
+    private void Close()
+    {
+        IsOpen = false;
+        StateHasChanged();
+        OnClose.InvokeAsync();
+    }
+}

--- a/CompetitionResults/Data/Translation.cs
+++ b/CompetitionResults/Data/Translation.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CompetitionResults.Data
+{
+    public class Translation
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Key { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/CompetitionResults/Data/TranslationService.cs
+++ b/CompetitionResults/Data/TranslationService.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace CompetitionResults.Data
+{
+    public class TranslationService
+    {
+        private readonly CompetitionDbContext _context;
+
+        public TranslationService(CompetitionDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<Translation>> GetAllTranslationsAsync()
+        {
+            return await _context.Translations.ToListAsync();
+        }
+
+        public async Task AddOrUpdateTranslationAsync(Translation translation)
+        {
+            if (translation.Id == 0)
+            {
+                _context.Translations.Add(translation);
+            }
+            else
+            {
+                _context.Translations.Update(translation);
+            }
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteTranslationAsync(int id)
+        {
+            var tr = await _context.Translations.FindAsync(id);
+            if (tr != null)
+            {
+                _context.Translations.Remove(tr);
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task<string> GetValueAsync(string key)
+        {
+            var tr = await _context.Translations.FirstOrDefaultAsync(t => t.Key == key);
+            return tr?.Value ?? key;
+        }
+    }
+}

--- a/CompetitionResults/Program.cs
+++ b/CompetitionResults/Program.cs
@@ -74,7 +74,8 @@ namespace CompetitionResults
 			builder.Services.AddScoped<ThrowerService>();
 			builder.Services.AddScoped<CategoryService>();
 			builder.Services.AddScoped<DisciplineService>();
-			builder.Services.AddScoped<ResultService>();
+            builder.Services.AddScoped<ResultService>();
+            builder.Services.AddScoped<TranslationService>();
 
 			builder.Services.AddScoped<NotificationHub>();
 


### PR DESCRIPTION
## Summary
- add `Translation` entity and service for localized text
- seed Czech translations in `CompetitionDbContext`
- create admin page to edit translations
- integrate translation service with `ThrowerService`
- expose Translations page in navigation
- update tests to include translations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc43fb200832c8cd7fe432172dbdd