### PR TITLE
Add language-specific translations

### DIFF
--- a/CompetitionResults.Tests/InMemoryDbFixture.cs
+++ b/CompetitionResults.Tests/InMemoryDbFixture.cs
@@ -13,6 +13,7 @@ public class InMemoryDbFixture : IDisposable
     public DisciplineService DisciplineService { get; }
     public CompetitionService CompetitionService { get; }
     public ThrowerService ThrowerService { get; }
+    public TranslationService TranslationService { get; }
 
     public InMemoryDbFixture()
     {
@@ -26,14 +27,40 @@ public class InMemoryDbFixture : IDisposable
         Context.Disciplines.AddRange(SeedData.Disciplines);
         Context.Throwers.AddRange(SeedData.Throwers);
         Context.Results.AddRange(SeedData.Results);
+        Context.Translations.AddRange(new[]
+        {
+            new Translation { Id = 1, Key = "Camping on site", LocalLanguage = "CZ", Value = "Kempování na místě" },
+            new Translation { Id = 2, Key = "Want T-Shirt", LocalLanguage = "CZ", Value = "Chci tričko" },
+            new Translation { Id = 3, Key = "T-Shirt Size", LocalLanguage = "CZ", Value = "Velikost trička" },
+            new Translation { Id = 4, Key = "Registration for competition", LocalLanguage = "CZ", Value = "Registrace do závodu" },
+            new Translation { Id = 5, Key = "General Announcement", LocalLanguage = "CZ", Value = "Obecná zpráva" },
+            new Translation { Id = 6, Key = "Important - Payment for competition", LocalLanguage = "CZ", Value = "Dulezite - Platba za registraci" },
+            new Translation { Id = 7, Key = "You have been successfully registered to competition:", LocalLanguage = "CZ", Value = "Byl/a jste úspěšně registrován/a na soutěž:" },
+            new Translation { Id = 8, Key = "Name", LocalLanguage = "CZ", Value = "Jméno" },
+            new Translation { Id = 9, Key = "Surname", LocalLanguage = "CZ", Value = "Příjmení" },
+            new Translation { Id = 10, Key = "Nickname", LocalLanguage = "CZ", Value = "Přezdívka" },
+            new Translation { Id = 11, Key = "Nationality", LocalLanguage = "CZ", Value = "Národnost" },
+            new Translation { Id = 12, Key = "Club name", LocalLanguage = "CZ", Value = "Jméno klubu" },
+            new Translation { Id = 13, Key = "Email", LocalLanguage = "CZ", Value = "Email" },
+            new Translation { Id = 14, Key = "Note", LocalLanguage = "CZ", Value = "Poznámka" },
+            new Translation { Id = 15, Key = "Category", LocalLanguage = "CZ", Value = "Kategorie" },
+            new Translation { Id = 16, Key = "Hello,", LocalLanguage = "CZ", Value = "Dobrý den," },
+            new Translation { Id = 17, Key = "This email is automatically generated because you have registered for the competition and have not yet paid.", LocalLanguage = "CZ", Value = "Tento email je automaticky generován, protože jste se zaregistrovali na soutěž a ještě jste nezaplatili." },
+            new Translation { Id = 18, Key = "The limit for the number of participants has been set to {0}. Registration is final only after payment.", LocalLanguage = "CZ", Value = "Limit pro počet účastníků byl nastaven na {0}. Registrace je finální až po zaplacení." },
+            new Translation { Id = 19, Key = "Currently, {0} out of {1} participants have paid.", LocalLanguage = "CZ", Value = "Aktuálně má zaplaceno {0} z {1} účastníků." },
+            new Translation { Id = 20, Key = "Please pay as soon as possible, otherwise someone else will be faster than you and you will not be able to participate in the competition.", LocalLanguage = "CZ", Value = "Prosím, zaplaťte co nejdříve, jinak Vás předběhne někdo jiný a nebudete se moci zúčastnit soutěže." },
+            new Translation { Id = 21, Key = "Thank you.", LocalLanguage = "CZ", Value = "Děkujeme." },
+            new Translation { Id = 22, Key = "Team {0}", LocalLanguage = "CZ", Value = "Tým {0}" }
+        });
         Context.SaveChanges();
 
         var notificationHub = new NotificationHub(null!);
+        TranslationService = new TranslationService(Context);
         ResultService = new ResultService(Context, notificationHub);
         CategoryService = new CategoryService(Context);
         DisciplineService = new DisciplineService(Context);
         CompetitionService = new CompetitionService(Context);
-        ThrowerService = new ThrowerService(Context, notificationHub, new ConfigurationBuilder().Build());
+        ThrowerService = new ThrowerService(Context, notificationHub, new ConfigurationBuilder().Build(), TranslationService);
     }
 
     public void Dispose()

--- a/CompetitionResults/CompetitionDbContext.cs
+++ b/CompetitionResults/CompetitionDbContext.cs
@@ -12,6 +12,7 @@
         public DbSet<Category> Categories { get; set; }
         public DbSet<Discipline> Disciplines { get; set; }
         public DbSet<Results> Results { get; set; }
+        public DbSet<Translation> Translations { get; set; }
 
         public CompetitionDbContext(DbContextOptions<CompetitionDbContext> options)
             : base(options)
@@ -97,6 +98,31 @@
 
             modelBuilder.Entity<Thrower>().HasData(
                 new Thrower { Id = 1, Name = "Zuzana", Surname = "Koreňová", Nickname = "Suzanne KO", Nationality = "CZ", CompetitionId = 1, CategoryId = 2, StartingNumber = 1 }
+            );
+
+            modelBuilder.Entity<Translation>().HasData(
+                new Translation { Id = 1, Key = "Camping on site", LocalLanguage = "CZ", Value = "Kempování na místě" },
+                new Translation { Id = 2, Key = "Want T-Shirt", LocalLanguage = "CZ", Value = "Chci tričko" },
+                new Translation { Id = 3, Key = "T-Shirt Size", LocalLanguage = "CZ", Value = "Velikost trička" },
+                new Translation { Id = 4, Key = "Registration for competition", LocalLanguage = "CZ", Value = "Registrace do závodu" },
+                new Translation { Id = 5, Key = "General Announcement", LocalLanguage = "CZ", Value = "Obecná zpráva" },
+                new Translation { Id = 6, Key = "Important - Payment for competition", LocalLanguage = "CZ", Value = "Dulezite - Platba za registraci" },
+                new Translation { Id = 7, Key = "You have been successfully registered to competition:", LocalLanguage = "CZ", Value = "Byl/a jste úspěšně registrován/a na soutěž:" },
+                new Translation { Id = 8, Key = "Name", LocalLanguage = "CZ", Value = "Jméno" },
+                new Translation { Id = 9, Key = "Surname", LocalLanguage = "CZ", Value = "Příjmení" },
+                new Translation { Id = 10, Key = "Nickname", LocalLanguage = "CZ", Value = "Přezdívka" },
+                new Translation { Id = 11, Key = "Nationality", LocalLanguage = "CZ", Value = "Národnost" },
+                new Translation { Id = 12, Key = "Club name", LocalLanguage = "CZ", Value = "Jméno klubu" },
+                new Translation { Id = 13, Key = "Email", LocalLanguage = "CZ", Value = "Email" },
+                new Translation { Id = 14, Key = "Note", LocalLanguage = "CZ", Value = "Poznámka" },
+                new Translation { Id = 15, Key = "Category", LocalLanguage = "CZ", Value = "Kategorie" },
+                new Translation { Id = 16, Key = "Hello,", LocalLanguage = "CZ", Value = "Dobrý den," },
+                new Translation { Id = 17, Key = "This email is automatically generated because you have registered for the competition and have not yet paid.", LocalLanguage = "CZ", Value = "Tento email je automaticky generován, protože jste se zaregistrovali na soutěž a ještě jste nezaplatili." },
+                new Translation { Id = 18, Key = "The limit for the number of participants has been set to {0}. Registration is final only after payment.", LocalLanguage = "CZ", Value = "Limit pro počet účastníků byl nastaven na {0}. Registrace je finální až po zaplacení." },
+                new Translation { Id = 19, Key = "Currently, {0} out of {1} participants have paid.", LocalLanguage = "CZ", Value = "Aktuálně má zaplaceno {0} z {1} účastníků." },
+                new Translation { Id = 20, Key = "Please pay as soon as possible, otherwise someone else will be faster than you and you will not be able to participate in the competition.", LocalLanguage = "CZ", Value = "Prosím, zaplaťte co nejdříve, jinak Vás předběhne někdo jiný a nebudete se moci zúčastnit soutěže." },
+                new Translation { Id = 21, Key = "Thank you.", LocalLanguage = "CZ", Value = "Děkujeme." },
+                new Translation { Id = 22, Key = "Team {0}", LocalLanguage = "CZ", Value = "Tým {0}" }
             );
         }
 

--- a/CompetitionResults/Components/Layout/NavMenu.razor
+++ b/CompetitionResults/Components/Layout/NavMenu.razor
@@ -40,12 +40,17 @@
 						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Categories
 					</NavLink>
 				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="disciplines">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="disciplines">
+                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
+                                        </NavLink>
+                                </div>
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="translations">
+                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Translations
+                                        </NavLink>
+                                </div>
+                                <div class="nav-item px-3">
 					<NavLink class="nav-link" href="throwers">
 						<span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Throwers
 					</NavLink>
@@ -79,16 +84,21 @@
 						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Categories
 					</NavLink>
 				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="disciplines">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="throwers">
-						<span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Throwers
-					</NavLink>
-				</div>
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="disciplines">
+                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
+                                        </NavLink>
+                                </div>
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="translations">
+                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Translations
+                                        </NavLink>
+                                </div>
+                                <div class="nav-item px-3">
+                                        <NavLink class="nav-link" href="throwers">
+                                                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Throwers
+                                        </NavLink>
+                                </div>
 				<div class="nav-item px-3">
 					<NavLink class="nav-link" href="scores">
 						<span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Scores

--- a/CompetitionResults/Components/Pages/ThrowersList.razor
+++ b/CompetitionResults/Components/Pages/ThrowersList.razor
@@ -252,14 +252,14 @@
 		}
 	}
 
-	private async Task SendUnpaidEmail(Thrower thrower)
-	{
-		var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send registration email to this thrower?");
-		if (confirmed)
-		{
-			ThrowerService.SendUnpaidEmail(thrower);
-		}
-	}
+        private async Task SendUnpaidEmail(Thrower thrower)
+        {
+            var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send registration email to this thrower?");
+            if (confirmed)
+            {
+                await ThrowerService.SendUnpaidEmail(thrower);
+            }
+        }
 
 	private async Task SendEmailsToUnpaid()
 	{
@@ -269,10 +269,10 @@
 			var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send emails to {unpaidThrowers.Count} unpaid throwers?");
 			if (confirmed)
 			{
-				foreach (var thrower in unpaidThrowers)
-				{
-					ThrowerService.SendUnpaidEmail(thrower);
-				}
+                                foreach (var thrower in unpaidThrowers)
+                                {
+                                        await ThrowerService.SendUnpaidEmail(thrower);
+                                }
 				await JSRuntime.InvokeVoidAsync("alert", "Emails sent to unpaid throwers.");
 			}
 		}

--- a/CompetitionResults/Components/Pages/TranslationsList.razor
+++ b/CompetitionResults/Components/Pages/TranslationsList.razor
@@ -1,0 +1,92 @@
+@page "/translations"
+@using CompetitionResults.Data
+@using CompetitionResults.Components.Shared
+@inject TranslationService TranslationService
+@inject CompetitionService CompetitionService
+@inject CompetitionStateService CompetitionState
+@inject IJSRuntime JSRuntime
+@implements IDisposable
+
+<h3>Translations</h3>
+
+<AuthorizeView Roles="Admin, Manager">
+    <Authorized>
+        <TranslationEditModal @ref="translationEditModal" OnClose="HandleModalClose" Translation="currentTranslation" OnFormSubmit="HandleFormSubmit" />
+
+        @if (translations == null)
+        {
+            <p><em>Loading...</em></p>
+        }
+        else
+        {
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var tr in translations)
+                    {
+                        <tr>
+                            <td>@tr.Key</td>
+                            <td>@tr.Value</td>
+                            <td>
+                                <button @onclick="() => EditTranslation(tr)">Edit</button>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </Authorized>
+    <NotAuthorized>
+        <p>You're not loggged in.</p>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private TranslationEditModal translationEditModal;
+    private List<Translation> translations;
+    private Translation currentTranslation = new Translation();
+    private string localLanguage = "";
+
+    protected override async Task OnInitializedAsync()
+    {
+        CompetitionState.OnCompetitionChanged += LoadData;
+        await LoadData();
+    }
+
+    private async Task LoadData()
+    {
+        var comp = await CompetitionService.GetCompetitionByIdAsync(CompetitionState.SelectedCompetitionId);
+        localLanguage = comp?.LocalLanguage ?? "";
+        translations = await TranslationService.GetTranslationsByLanguageAsync(localLanguage);
+        StateHasChanged();
+    }
+
+    private void EditTranslation(Translation tr)
+    {
+        currentTranslation = tr;
+        currentTranslation.LocalLanguage = localLanguage;
+        translationEditModal.Open();
+    }
+
+
+    private async Task HandleFormSubmit()
+    {
+        await LoadData();
+    }
+
+    private async Task HandleModalClose()
+    {
+        await LoadData();
+    }
+
+    public void Dispose()
+    {
+        CompetitionState.OnCompetitionChanged -= LoadData;
+    }
+}

--- a/CompetitionResults/Components/Shared/TranslationEditModal.razor
+++ b/CompetitionResults/Components/Shared/TranslationEditModal.razor
@@ -1,0 +1,84 @@
+@using CompetitionResults.Data
+@inject TranslationService TranslationService
+
+<div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <EditForm Model="@_translation" OnValidSubmit="HandleValidSubmit">
+                <DataAnnotationsValidator />
+                <ValidationSummary />
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit Translation</h5>
+                    <button type="button" class="btn-close" @onclick="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-grid">
+                        <div>
+                            <label for="key">Key:</label>
+                            <InputText id="key" @bind-Value="@_translation.Key" readonly />
+                        </div>
+                        <div>
+                            <label for="value">Value:</label>
+                            <InputText id="value" @bind-Value="@_translation.Value" />
+                        </div>
+                        <div>
+                            <label for="language">Language:</label>
+                            <InputText id="language" @bind-Value="@_translation.LocalLanguage" readonly />
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
+                    <button type="submit" class="btn btn-primary">Save changes</button>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+</div>
+
+@code {
+    public bool IsOpen { get; private set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    private Translation _translation;
+
+    protected override void OnInitialized()
+    {
+        _translation = new Translation();
+    }
+
+    [Parameter]
+    public Translation Translation
+    {
+        get => _translation;
+        set
+        {
+            if (_translation != value)
+            {
+                _translation = value;
+            }
+        }
+    }
+
+    [Parameter]
+    public EventCallback OnFormSubmit { get; set; }
+
+    private async Task HandleValidSubmit()
+    {
+        IsOpen = false;
+        await TranslationService.AddOrUpdateTranslationAsync(_translation);
+        await OnFormSubmit.InvokeAsync(null);
+    }
+
+    public void Open()
+    {
+        IsOpen = true;
+        StateHasChanged();
+    }
+
+    private void Close()
+    {
+        IsOpen = false;
+        StateHasChanged();
+        OnClose.InvokeAsync();
+    }
+}

--- a/CompetitionResults/Data/ThrowerService.cs
+++ b/CompetitionResults/Data/ThrowerService.cs
@@ -11,15 +11,18 @@ namespace CompetitionResults.Data
 		private readonly NotificationHub _notificationHub;
 		private readonly CompetitionDbContext _context;
         private readonly IConfiguration _configuration;
+        private readonly TranslationService _translationService;
 
         public ThrowerService(CompetitionDbContext context,
-			NotificationHub notificationHub,
-            IConfiguration configuration)
+                        NotificationHub notificationHub,
+            IConfiguration configuration,
+            TranslationService translationService)
         {
             _context = context;
-			_notificationHub = notificationHub;
+                        _notificationHub = notificationHub;
             _configuration = configuration;
-		}
+            _translationService = translationService;
+                }
 
         public async Task<List<Thrower>> GetAllThrowersAsync(int competitionId)
         {
@@ -84,7 +87,7 @@ namespace CompetitionResults.Data
             }
         }
 
-        public void SendUnpaidEmail(Thrower thrower)
+        public async Task SendUnpaidEmail(Thrower thrower)
         {
             if (thrower.Email != null && !thrower.DoNotSendRegistrationEmail)
             {
@@ -93,15 +96,16 @@ namespace CompetitionResults.Data
                     !string.IsNullOrEmpty(competition.LocalLanguage) &&
                     thrower.Nationality.ToUpper() == competition.LocalLanguage.ToUpper())
                 {
-                    var email = $"Dobrý den,\n\n";
-                    email += $"Tento email je automaticky generován, protože jste se zaregistrovali na soutěž a ještě jste nezaplatili.\n";
-                    email += $"Limit pro počet účastníků byl nastaven na {thrower.Competition.MaxCompetitorCount}.Registrace je finální až po zaplacení.\n\n";
-                    email += $"Aktuálně má zaplaceno {thrower.Competition.Throwers.Count(t => t.PaymentDone)} z {thrower.Competition.Throwers.Count} účastníků.\n\n";
-                    email += $"Prosím, zaplaťte co nejdříve, jinak Vás předběhne někdo jiný a nebudete se moci zúčastnit soutěže.\n\n";
-                    email += $"Děkujeme.\n\n";
-                    email += $"Tým {thrower.Competition.Name}";
+                    var lang = competition.LocalLanguage;
+                    var email = $"{await _translationService.GetValueAsync("Hello,", lang)}\n\n";
+                    email += string.Format(await _translationService.GetValueAsync("This email is automatically generated because you have registered for the competition and have not yet paid.", lang)) + "\n";
+                    email += string.Format(await _translationService.GetValueAsync("The limit for the number of participants has been set to {0}. Registration is final only after payment.", lang), thrower.Competition.MaxCompetitorCount) + "\n\n";
+                    email += string.Format(await _translationService.GetValueAsync("Currently, {0} out of {1} participants have paid.", lang), thrower.Competition.Throwers.Count(t => t.PaymentDone), thrower.Competition.Throwers.Count) + "\n\n";
+                    email += await _translationService.GetValueAsync("Please pay as soon as possible, otherwise someone else will be faster than you and you will not be able to participate in the competition.", lang) + "\n\n";
+                    email += await _translationService.GetValueAsync("Thank you.", lang) + "\n\n";
+                    email += string.Format(await _translationService.GetValueAsync("Team {0}", lang), thrower.Competition.Name);
 
-                    SendEmail(thrower.Email, "Dulezite - Platba za registraci", email);
+                    SendEmail(thrower.Email, await _translationService.GetValueAsync("Important - Payment for competition", lang), email);
                 }
                 else
                 {
@@ -174,34 +178,35 @@ namespace CompetitionResults.Data
             SendEmail(thrower.Email, "Registration for competition", email);
 		}
 
-		private async Task SendRegistrationEmailLocal(Thrower thrower)
-		{
-			var competition = await _context.Competitions.FindAsync(thrower.CompetitionId);
+                private async Task SendRegistrationEmailLocal(Thrower thrower)
+                {
+                        var competition = await _context.Competitions.FindAsync(thrower.CompetitionId);
+                        var lang = competition.LocalLanguage;
 
-			// Send email to the thrower with all details of his registration
-			var email = $"Byl/a jste úspěšně registrován/a na soutěž: {competition.Name}.\n";
-			// Add all details of thrower
-			email += $"Jméno: {thrower.Name}\n";
-			email += $"Příjmení: {thrower.Surname}\n";
-			email += $"Přezdívka: {thrower.Nickname}\n";
-			email += $"Národnost: {thrower.Nationality}\n";
-			email += $"Jméno klubu: {thrower.ClubName}\n";
-			email += $"Email: {thrower.Email}\n";
-			email += $"Poznámka: {thrower.Note}\n";
-			email += $"Kategorie: {thrower.Category.Name}\n";
-			email += $"Kempování na místě: {thrower.IsCampingOnSite}\n";
-			email += $"Chci tričko: {thrower.WantTShirt}\n";
-			if (thrower.WantTShirt)
-			{
-				email += $"Velikost trička: {thrower.TShirtSize}\n";
-			}
+                        // Send email to the thrower with all details of his registration
+                        var email = string.Format(await _translationService.GetValueAsync("You have been successfully registered to competition:", lang), competition.Name) + "\n";
+                        // Add all details of thrower
+                        email += $"{await _translationService.GetValueAsync("Name", lang)}: {thrower.Name}\n";
+                        email += $"{await _translationService.GetValueAsync("Surname", lang)}: {thrower.Surname}\n";
+                        email += $"{await _translationService.GetValueAsync("Nickname", lang)}: {thrower.Nickname}\n";
+                        email += $"{await _translationService.GetValueAsync("Nationality", lang)}: {thrower.Nationality}\n";
+                        email += $"{await _translationService.GetValueAsync("Club name", lang)}: {thrower.ClubName}\n";
+                        email += $"{await _translationService.GetValueAsync("Email", lang)}: {thrower.Email}\n";
+                        email += $"{await _translationService.GetValueAsync("Note", lang)}: {thrower.Note}\n";
+                        email += $"{await _translationService.GetValueAsync("Category", lang)}: {thrower.Category.Name}\n";
+                        email += $"{await _translationService.GetValueAsync("Camping on site", lang)}: {thrower.IsCampingOnSite}\n";
+                        email += $"{await _translationService.GetValueAsync("Want T-Shirt", lang)}: {thrower.WantTShirt}\n";
+                        if (thrower.WantTShirt)
+                        {
+                                email += $"{await _translationService.GetValueAsync("T-Shirt Size", lang)}: {thrower.TShirtSize}\n";
+                        }
 
 			email += $"\n";
 
 			email += competition.EmailTemplateFooterLocal;
 
-			SendEmail(thrower.Email, "Registrace do závodu", email);
-		}
+                        SendEmail(thrower.Email, await _translationService.GetValueAsync("Registration for competition", lang), email);
+                }
 
 		public void SendEmail(string toEmail, string subject, string body)
         {

--- a/CompetitionResults/Data/Translation.cs
+++ b/CompetitionResults/Data/Translation.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CompetitionResults.Data
+{
+    public class Translation
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Key { get; set; }
+
+        [Required]
+        public string LocalLanguage { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/CompetitionResults/Data/TranslationService.cs
+++ b/CompetitionResults/Data/TranslationService.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace CompetitionResults.Data
+{
+    public class TranslationService
+    {
+        private readonly CompetitionDbContext _context;
+
+        public TranslationService(CompetitionDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<Translation>> GetTranslationsByLanguageAsync(string language)
+        {
+            return await _context.Translations
+                .Where(t => t.LocalLanguage == language)
+                .ToListAsync();
+        }
+
+        public async Task AddOrUpdateTranslationAsync(Translation translation)
+        {
+            if (translation.Id == 0)
+            {
+                _context.Translations.Add(translation);
+            }
+            else
+            {
+                _context.Translations.Update(translation);
+            }
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteTranslationAsync(int id)
+        {
+            var tr = await _context.Translations.FindAsync(id);
+            if (tr != null)
+            {
+                _context.Translations.Remove(tr);
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task<string> GetValueAsync(string key, string language)
+        {
+            var tr = await _context.Translations.FirstOrDefaultAsync(t => t.Key == key && t.LocalLanguage == language);
+            return tr?.Value ?? key;
+        }
+    }
+}

--- a/CompetitionResults/Program.cs
+++ b/CompetitionResults/Program.cs
@@ -74,7 +74,8 @@ namespace CompetitionResults
 			builder.Services.AddScoped<ThrowerService>();
 			builder.Services.AddScoped<CategoryService>();
 			builder.Services.AddScoped<DisciplineService>();
-			builder.Services.AddScoped<ResultService>();
+            builder.Services.AddScoped<ResultService>();
+            builder.Services.AddScoped<TranslationService>();
 
 			builder.Services.AddScoped<NotificationHub>();
 


### PR DESCRIPTION
## Summary
- link translations to the competition `LocalLanguage`
- fetch translations filtered by language and display them on the Translations page
- keep translation key and language read-only in the modal editor
- use `LocalLanguage` when sending localized emails
- update seeding and test fixture with language information

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc43fb200832c8cd7fe432172dbdd