### PR TITLE
Update competition access logic

### DIFF
--- a/CompetitionResults/Components/Pages/Administration.razor
+++ b/CompetitionResults/Components/Pages/Administration.razor
@@ -7,6 +7,8 @@
 @inject UserManager<ApplicationUser> _UserManager
 @inject RoleManager<IdentityRole> _RoleManager
 @inject AuthenticationStateProvider AuthenticationStateProvider
+@inject CompetitionService CompetitionService
+@inject CompetitionStateService CompetitionState
 <h3>Administration</h3>
 <AuthorizeView Roles="Admin, Manager, User">
 	<Authorized>
@@ -336,11 +338,13 @@
 				return;
 			}
 
-			if (!string.IsNullOrEmpty(CurrentUserRole))
-			{
-				await _UserManager.AddToRoleAsync(newUser, CurrentUserRole);
-			}
-		}
+                        if (!string.IsNullOrEmpty(CurrentUserRole))
+                        {
+                                await _UserManager.AddToRoleAsync(newUser, CurrentUserRole);
+                        }
+
+                        await CompetitionService.AssignManagerToCompetitionAsync(newUser.Id, CompetitionState.SelectedCompetitionId);
+                }
 
 		ShowPopup = false;
 		GetUsers(); // Refresh tabulky

--- a/CompetitionResults/Components/Pages/Managers.razor
+++ b/CompetitionResults/Components/Pages/Managers.razor
@@ -1,9 +1,12 @@
 @page "/managers"
 @using CompetitionResults.Data
+@using CompetitionResults.Constants
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.Authorization
 @inject CompetitionService CompetitionServiceInstance
 @inject UserManager<ApplicationUser> UserManager
+@inject RoleManager<IdentityRole> RoleManager
+@inject UserIdStateService UserIdStateService
 
 <h3>Competition Manager Assignments</h3>
 
@@ -52,11 +55,30 @@
     private List<Competition> competitions = new();
     private ApplicationUser selectedUser;
     private HashSet<int> assignedCompetitionIds = new();
+    private ApplicationUser currentUser;
+    private bool isAdmin;
+    private bool isManager;
 
     protected override async Task OnInitializedAsync()
     {
-        users = UserManager.Users.ToList();
-        competitions = await CompetitionServiceInstance.GetAllCompetitionsAsync();
+        var currentUserId = await UserIdStateService.GetUserIdAsync();
+        currentUser = await UserManager.FindByIdAsync(currentUserId);
+
+        isAdmin = await UserManager.IsInRoleAsync(currentUser, RoleNames.Admin);
+        isManager = await UserManager.IsInRoleAsync(currentUser, RoleNames.Manager);
+
+        if (isAdmin)
+        {
+            users = UserManager.Users.ToList();
+            competitions = await CompetitionServiceInstance.GetAllCompetitionsAsync();
+        }
+        else if (isManager)
+        {
+            var userUsers = await UserManager.GetUsersInRoleAsync(RoleNames.User);
+            var viewerUsers = await UserManager.GetUsersInRoleAsync(RoleNames.Viewer);
+            users = userUsers.Concat(viewerUsers).Where(u => u.Id != currentUserId).ToList();
+            competitions = await CompetitionServiceInstance.GetCompetitionsForManagerAsync(currentUserId);
+        }
     }
 
     private async Task OnUserChanged(ChangeEventArgs e)
@@ -78,6 +100,15 @@
         if (selectedUser == null)
         {
             return;
+        }
+
+        if (!isAdmin)
+        {
+            var roles = await UserManager.GetRolesAsync(selectedUser);
+            if (roles.Contains(RoleNames.Admin) || roles.Contains(RoleNames.Manager) || selectedUser.Id == currentUser.Id)
+            {
+                return;
+            }
         }
 
         if (assign)

--- a/CompetitionResults/Components/Shared/CompetitionDropdown.razor
+++ b/CompetitionResults/Components/Shared/CompetitionDropdown.razor
@@ -33,8 +33,16 @@
 
     private async void LoadData()
     {
-        //competitions = await CompetitionService.GetCompetitionsForManagerAsync(await UserIdStateService.GetUserIdAsync());
-        competitions = await CompetitionService.GetAllCompetitionsAsync();
+        var userId = await UserIdStateService.GetUserIdAsync();
+        if (string.IsNullOrEmpty(userId))
+        {
+            competitions = await CompetitionService.GetAllCompetitionsAsync();
+        }
+        else
+        {
+            competitions = await CompetitionService.GetCompetitionsForManagerAsync(userId);
+        }
+
         if (competitions != null && competitions.Count > 0 && CompetitionState.SelectedCompetitionId == 0)
         {
             // Automatically select the first competition
@@ -51,10 +59,8 @@
     private async void OnSelectionChange(ChangeEventArgs e)
     {
         int competitionId = int.Parse(e.Value.ToString());
-        //var managerCompetitions = await CompetitionService.GetCompetitionsForManagerAsync(await UserIdStateService.GetUserIdAsync());
-        var managerCompetitions = await CompetitionService.GetAllCompetitionsAsync();
 
-        if (managerCompetitions.Any(c => c.Id == competitionId))
+        if (competitions.Any(c => c.Id == competitionId))
         {
             CompetitionState.SelectedCompetitionId = competitionId;
             errorMessage = string.Empty; // Clear previous error messages if any


### PR DESCRIPTION
## Summary
- filter CompetitionDropdown to show assigned competitions when logged in
- restrict manager competition assignment abilities
- assign current competition to new users by default

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687017b9e804832c9b6ed97b26e47dfd