### PR TITLE
Restrict manager assigning competitions

### DIFF
--- a/CompetitionResults/Components/Pages/Administration.razor
+++ b/CompetitionResults/Components/Pages/Administration.razor
@@ -320,7 +320,10 @@
                                 await _UserManager.AddToRoleAsync(newUser, CurrentUserRole);
                         }
 
-                        await CompetitionService.AssignManagerToCompetitionAsync(newUser.Id, CompetitionState.SelectedCompetitionId);
+                        if (CurrentUser.IsInRole(ADMINISTRATION_ROLE))
+                        {
+                                await CompetitionService.AssignManagerToCompetitionAsync(newUser.Id, CompetitionState.SelectedCompetitionId);
+                        }
                 }
 
 		ShowPopup = false;

--- a/CompetitionResults/Components/Pages/Managers.razor
+++ b/CompetitionResults/Components/Pages/Managers.razor
@@ -112,6 +112,12 @@
 
         if (assign)
         {
+            if (!isAdmin && !assignedCompetitionIds.Contains(competitionId))
+            {
+                // Managers cannot assign competitions the user does not already have
+                return;
+            }
+
             await CompetitionServiceInstance.AssignManagerToCompetitionAsync(selectedUser.Id, competitionId);
             assignedCompetitionIds.Add(competitionId);
         }


### PR DESCRIPTION
## Summary
- restrict managers from adding competitions to accounts unless already assigned
- only admins may auto-assign competition when creating a new user

## Testing
- `dotnet test` *(fails: .NET 9.0 SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68702cbb6404832cac15b964647eb24a