### PR TITLE
Refactor naming in ResultService

### DIFF
--- a/CompetitionResults/Components/Pages/ResultsThrower.razor
+++ b/CompetitionResults/Components/Pages/ResultsThrower.razor
@@ -91,7 +91,7 @@ else
 
         foreach (var disc in disciplines)
         {
-            var discResults = await ResultsService.GetMixedRankedResultsAsync(disc.Id, compId);
+            var discResults = await ResultsService.GetRankedResultsAsync(disc.Id, compId);
             allDisciplineResults[disc.Id] = discResults;
 
             selectedThrowerResults.AddRange(discResults.Where(r => r.ThrowerId == throwerId));


### PR DESCRIPTION
## Summary
- rename `AssignPointsAwards` to `CalculateAwardPoints`
- rename `GetMixedRankedResultsAsync` to `GetRankedResultsAsync`
- use clearer local variable names in `ResultService`
- update component to call the new method name

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687031d51dac832cad0b31b9a263bb66