### PR TITLE
Add localization support with Czech translations and language selector

### DIFF
--- a/CompetitionResults/Components/App.razor
+++ b/CompetitionResults/Components/App.razor
@@ -1,5 +1,7 @@
+@using System.Globalization
+
 <!DOCTYPE html>
-<html lang="en">
+<html lang="@CultureInfo.CurrentUICulture.TwoLetterISOLanguageName">
 
 <head>
     <meta charset="utf-8" />

--- a/CompetitionResults/Components/Layout/MainLayout.razor
+++ b/CompetitionResults/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
-﻿@using CompetitionResults.Components.Shared
+@using CompetitionResults.Components.Shared
 @inherits LayoutComponentBase
+@inject IStringLocalizer<SharedResource> L
 
 <div class="page">
     <div class="sidebar">
@@ -8,6 +9,7 @@
 
     <main>
         <div class="top-row px-4 auth">
+            <LanguageSelector />
             <CompetitionDropdown />
             <LoginDisplay />
         </div>
@@ -19,7 +21,7 @@
 </div>
 
 <div id="blazor-error-ui" data-nosnippet>
-    An unhandled error has occurred.
-    <a href="." class="reload">Reload</a>
+    @L["An unhandled error has occurred."]
+    <a href="." class="reload">@L["Reload"]</a>
     <span class="dismiss">🗙</span>
 </div>

--- a/CompetitionResults/Components/Layout/MainLayout.razor.css
+++ b/CompetitionResults/Components/Layout/MainLayout.razor.css
@@ -21,6 +21,11 @@ main {
     align-items: center;
 }
 
+.top-row ::deep .language-selector {
+    margin-right: auto;
+    max-width: 8rem;
+}
+
     .top-row ::deep a, .top-row ::deep .btn-link {
         white-space: nowrap;
         margin-left: 1.5rem;

--- a/CompetitionResults/Components/Layout/NavMenu.razor
+++ b/CompetitionResults/Components/Layout/NavMenu.razor
@@ -1,203 +1,203 @@
-﻿@implements IDisposable
-
+@implements IDisposable
+@inject IStringLocalizer<SharedResource> L
 @inject NavigationManager NavigationManager
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="" title="Competition Results">Results</a>
+        <a class="navbar-brand" href="" title='@L["Competition Results"]'>@L["Results"]</a>
     </div>
 </div>
 
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
+<input type="checkbox" title='@L["Navigation menu"]' class="navbar-toggler" />
 
 <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
     <nav class="nav flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
+                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> @L["Home"]
             </NavLink>
         </div>
 
         <AuthorizeView Roles="Admin">
-			<Authorized>	
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="administration">
-						<span class="bi bi-person-nav-menu" aria-hidden="true"></span> Users
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="competitions">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Competitions
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="managers">
-						<span class="bi bi-person-badge-nav-menu" aria-hidden="true"></span> Managers
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="categories">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Categories
-					</NavLink>
-				</div>
-                                <div class="nav-item px-3">
-                                        <NavLink class="nav-link" href="disciplines">
-                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
-                                        </NavLink>
-                                </div>
-                                <div class="nav-item px-3">
-                                        <NavLink class="nav-link" href="translations">
-                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Translations
-                                        </NavLink>
-                                </div>
-                                <div class="nav-item px-3">
-					<NavLink class="nav-link" href="throwers">
-						<span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Throwers
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="scores">
-						<span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Scores
-					</NavLink>
-				</div>
-			</Authorized>
-		</AuthorizeView>
-		<AuthorizeView Roles="Manager">
-			<Authorized>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="administration">
-						<span class="bi bi-person-nav-menu" aria-hidden="true"></span> Users
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="competitions">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Competitions
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="managers">
-						<span class="bi bi-person-badge-nav-menu" aria-hidden="true"></span> Managers
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="categories">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Categories
-					</NavLink>
-				</div>
-                                <div class="nav-item px-3">
-                                        <NavLink class="nav-link" href="disciplines">
-                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Disciplines
-                                        </NavLink>
-                                </div>
-                                <div class="nav-item px-3">
-                                        <NavLink class="nav-link" href="translations">
-                                                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Translations
-                                        </NavLink>
-                                </div>
-                                <div class="nav-item px-3">
-                                        <NavLink class="nav-link" href="throwers">
-                                                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Throwers
-                                        </NavLink>
-                                </div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="scores">
-						<span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Scores
-					</NavLink>
-				</div>
-			</Authorized>
-		</AuthorizeView>
-		<AuthorizeView Roles="User">
-			<Authorized>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="administration">
-						<span class="bi bi-person-nav-menu" aria-hidden="true"></span> Users
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="scores">
-						<span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Scores
-					</NavLink>
-				</div>
-			</Authorized>
-		</AuthorizeView>
-		<AuthorizeView>
-			<Authorized>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsstatic" title="Results Static">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (S)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsone" title="Results by discipline">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (G)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsthrower" title="Results by thrower">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (T)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsselector" title="Results selection">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (X)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsbycountry" title="Results by country">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (C)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="medals-by-nation" title="Medals">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Medals
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink href="/account/logout" class="nav-link">
-						<span class="bi bi-lock-nav-menu" aria-hidden="true"></span> Log out
-					</NavLink>
-				</div>
-			</Authorized>
-			<NotAuthorized>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="registration" title="Registration">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Registration
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsstatic" title="Results Static">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (S)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsone" title="Results by discipline">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (G)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsthrower" title="Results by thrower">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (T)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsselector" title="Results selection">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (X)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="resultsbycountry" title="Results by country">
-						<span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Results (C)
-					</NavLink>
-				</div>
-				<div class="nav-item px-3">
-					<NavLink class="nav-link" href="medals-by-nation">
-						<span class="oi oi-medal" aria-hidden="true"></span> Medals
-					</NavLink>
-				</div>
-			</NotAuthorized>
-		</AuthorizeView>
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="administration">
+                        <span class="bi bi-person-nav-menu" aria-hidden="true"></span> @L["Users"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="competitions">
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Competitions"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="managers">
+                        <span class="bi bi-person-badge-nav-menu" aria-hidden="true"></span> @L["Managers"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="categories">
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Categories"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="disciplines">
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Disciplines"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="translations">
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Translations"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="throwers">
+                        <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> @L["Throwers"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="scores">
+                        <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> @L["Scores"]
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
+        <AuthorizeView Roles="Manager">
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="administration">
+                        <span class="bi bi-person-nav-menu" aria-hidden="true"></span> @L["Users"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="competitions">
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Competitions"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="managers">
+                        <span class="bi bi-person-badge-nav-menu" aria-hidden="true"></span> @L["Managers"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="categories">
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Categories"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="disciplines">
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Disciplines"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="translations">
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Translations"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="throwers">
+                        <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> @L["Throwers"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="scores">
+                        <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> @L["Scores"]
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
+        <AuthorizeView Roles="User">
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="administration">
+                        <span class="bi bi-person-nav-menu" aria-hidden="true"></span> @L["Users"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="scores">
+                        <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> @L["Scores"]
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
+        <AuthorizeView>
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsstatic" title='@L["Results Static"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (S)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsone" title='@L["Results by discipline"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (G)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsthrower" title='@L["Results by thrower"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (T)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsselector" title='@L["Results selection"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (X)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsbycountry" title='@L["Results by country"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (C)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="medals-by-nation" title='@L["Medals"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Medals"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink href="/account/logout" class="nav-link">
+                        <span class="bi bi-lock-nav-menu" aria-hidden="true"></span> @L["Log out"]
+                    </NavLink>
+                </div>
+            </Authorized>
+            <NotAuthorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="registration" title='@L["Registration"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Registration"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsstatic" title='@L["Results Static"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (S)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsone" title='@L["Results by discipline"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (G)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsthrower" title='@L["Results by thrower"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (T)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsselector" title='@L["Results selection"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (X)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="resultsbycountry" title='@L["Results by country"]'>
+                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Results (C)"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="medals-by-nation">
+                        <span class="oi oi-medal" aria-hidden="true"></span> @L["Medals"]
+                    </NavLink>
+                </div>
+            </NotAuthorized>
+        </AuthorizeView>
     </nav>
-	<div><img src="bt.png" width="150" style="margin-left:15px;background-color: white;border-radius: 15px;padding: 5px;" /></div>
+    <div><img src="bt.png" width="150" style="margin-left:15px;background-color: white;border-radius: 15px;padding: 5px;" /></div>
 </div>
 
 @code {
@@ -220,4 +220,3 @@
         NavigationManager.LocationChanged -= OnLocationChanged;
     }
 }
-

--- a/CompetitionResults/Components/Pages/CompetitionsList.razor
+++ b/CompetitionResults/Components/Pages/CompetitionsList.razor
@@ -1,68 +1,74 @@
-﻿@page "/competitions"
+@page "/competitions"
 @using CompetitionResults.Data
 @using CompetitionResults.Components.Shared
 @using System.Security.Claims
 @inject CompetitionService CompetitionService
 @inject UserIdStateService UserIdStateService
 @inject IJSRuntime JSRuntime
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Competitions List</h3>
+<h3>@L["Competitions List"]</h3>
 <AuthorizeView Roles="Admin, Manager">
-	<Authorized>
-<button @onclick="AddNew">Add New Competition</button>
+    <Authorized>
+        <button @onclick="AddNew">@L["Add New Competition"]</button>
 
-<CompetitionEditModal @ref="competitionEditModal" OnClose="HandleModalClose" Category="currentCompetition" OnFormSubmit="HandleFormSubmit" />
+        <CompetitionEditModal @ref="competitionEditModal" OnClose="HandleModalClose" Category="currentCompetition" OnFormSubmit="HandleFormSubmit" />
 
-@if (competitions == null)
-{
-    <p><em>Loading...</em></p>
-}
-else
-{
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Description</th>
-                        <th>Camping</th>
-                        <th>T-Shirt</th>
-                        <th>T-Shirt Link</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var category in competitions)
-            {
-                <tr>
-                    <td>@category.Name</td>
-                    <td>@category.Description</td>
-                    <td>@(category.CampingOnSiteAvailable ? "Yes" : "No")</td>
-                    <td>@(category.TShirtAvailable ? "Yes" : "No")</td>
-                    <td>@category.TShirtLink</td>
-                    <td>
-                        <button @onclick="() => EditCompetition(category)">Edit</button>
-                        <button @onclick="() => DeleteCompetition(category.Id)">Delete</button>
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
-}
+        @if (competitions == null)
+        {
+            <p><em>@L["Loading..."]</em></p>
+        }
+        else if (!competitions.Any())
+        {
+            <p>@L["No competitions found."]</p>
+        }
+        else
+        {
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>@L["Name"]</th>
+                        <th>@L["Description"]</th>
+                        <th>@L["Camping"]</th>
+                        <th>@L["T-Shirt"]</th>
+                        <th>@L["T-Shirt Link"]</th>
+                        <th>@L["Actions"]</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var category in competitions)
+                    {
+                        <tr>
+                            <td>@category.Name</td>
+                            <td>@category.Description</td>
+                            <td>@(category.CampingOnSiteAvailable ? L["Yes"] : L["No"])</td>
+                            <td>@(category.TShirtAvailable ? L["Yes"] : L["No"])</td>
+                            <td>@category.TShirtLink</td>
+                            <td>
+                                <button @onclick="() => EditCompetition(category)">@L["Edit"]</button>
+                                <button @onclick="() => DeleteCompetition(category.Id)">@L["Delete"]</button>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
 
     </Authorized>
     <NotAuthorized>
-        <p>You're not loggged in.</p>
+        <p>@L["You're not logged in."]</p>
     </NotAuthorized>
 </AuthorizeView>
 
 @code {
-    private CompetitionEditModal competitionEditModal;
-    private List<Competition> competitions;
+    private CompetitionEditModal? competitionEditModal;
+    private List<Competition>? competitions;
     private Competition currentCompetition = new Competition();
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
         LoadData();
+        return Task.CompletedTask;
     }
 
     private async void LoadData()
@@ -71,39 +77,45 @@ else
         StateHasChanged();
     }
 
-    private async void AddNew()
+    private async Task AddNew()
     {
-        currentCompetition = new Competition();
-        currentCompetition.CompetitionManagers = new List<CompetitionManager>();
-        currentCompetition.CompetitionManagers.Add(new CompetitionManager { ManagerId = await UserIdStateService.GetUserIdAsync() });
-        competitionEditModal.Open();
+        currentCompetition = new Competition
+        {
+            CompetitionManagers = new List<CompetitionManager>
+            {
+                new CompetitionManager { ManagerId = await UserIdStateService.GetUserIdAsync() }
+            }
+        };
+        competitionEditModal?.Open();
         StateHasChanged();
     }
 
     private void EditCompetition(Competition competition)
     {
         currentCompetition = competition;
-        competitionEditModal.Open();
+        competitionEditModal?.Open();
         StateHasChanged();
     }
 
     private async Task DeleteCompetition(int competitionId)
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete this competition?");
+        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to delete this competition?"]);
         if (confirmed)
         {
             await CompetitionService.DeleteCompetitionAsync(competitionId);
             LoadData();
-        }        
+        }
     }
 
-    private async Task HandleFormSubmit()
+    private Task HandleFormSubmit()
     {
         LoadData();
+        return Task.CompletedTask;
     }
 
-    private async Task HandleModalClose()
+    private Task HandleModalClose()
     {
         LoadData();
+        return Task.CompletedTask;
     }
 }

--- a/CompetitionResults/Components/Pages/Index.razor
+++ b/CompetitionResults/Components/Pages/Index.razor
@@ -1,25 +1,26 @@
-﻿@page "/"
+@page "/"
 @using System.Security.Claims
 @using CompetitionResults.Data
 @inject CompetitionService CompetitionService
 @inject CompetitionStateService CompetitionState
 @inject ResultService ResultsServiceInstance
 @inject IJSRuntime JSRuntime;
+@inject IStringLocalizer<SharedResource> L
 
-<PageTitle>Competition Scores</PageTitle>
+<PageTitle>@L["Competition Scores"]</PageTitle>
 
-<h1>Competition Scores</h1>
+<h1>@L["Competition Scores"]</h1>
 
-<p>App to make competition scoring easy and fast.</p>
+<p>@L["App to make competition scoring easy and fast."]</p>
 
 <AuthorizeView Roles="Admin">
     <Authorized>
-        <button @onclick="CreateBackup">Backup all data</button>
-        @* <button @onclick="ClearDatabase">Clear database</button> *@
-        <button @onclick="ClearScores">Clear competition scores</button>
-        @* <button @onclick="FillRandomScores">Fill random scores</button> *@
+        <button @onclick="CreateBackup">@L["Backup all data"]</button>
+        @* <button @onclick="ClearDatabase">@L["Clear database"]</button> *@
+        <button @onclick="ClearScores">@L["Clear competition scores"]</button>
+        @* <button @onclick="FillRandomScores">@L["Fill random scores"]</button> *@
         <InputFile id="fileInput" accept=".json" multiple="false" OnChange="HandleFileSelected" style="display:none" />
-        <button @onclick="TriggerFileInput">Import all data</button>
+        <button @onclick="TriggerFileInput">@L["Import all data"]</button>
     </Authorized>
     <NotAuthorized>
     </NotAuthorized>
@@ -27,10 +28,10 @@
 
 <AuthorizeView Roles="Manager">
     <Authorized>
-        <button @onclick="CreateCompBackup">Backup competition data</button>
-        <button @onclick="ClearScores">Clear competition scores</button>
+        <button @onclick="CreateCompBackup">@L["Backup competition data"]</button>
+        <button @onclick="ClearScores">@L["Clear competition scores"]</button>
         <InputFile id="compfileInput" accept=".json" multiple="false" OnChange="HandleCompFileSelected" style="display:none" />
-        <button @onclick="TriggerCompFileInput">Import competition data</button>
+        <button @onclick="TriggerCompFileInput">@L["Import competition data"]</button>
     </Authorized>
     <NotAuthorized>
     </NotAuthorized>
@@ -59,7 +60,7 @@
 
     private async void ClearScores()
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to clear all results?");
+        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to clear all results?"]);
         if (confirmed)
         {
             await ResultsServiceInstance.DeleteResultsAsync(CompetitionState.SelectedCompetitionId);
@@ -68,7 +69,7 @@
 
     private async void FillRandomScores()
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Generate random scores for all disciplines and throwers?");
+        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Generate random scores for all disciplines and throwers?"]);
         if (confirmed)
         {
             await ResultsServiceInstance.FillRandomScoresAsync(CompetitionState.SelectedCompetitionId);
@@ -77,7 +78,7 @@
 
     private async void ClearDatabase()
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to clear database?");
+        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to clear database?"]);
         if (confirmed)
         {
             await CompetitionService.ClearDBAsync();

--- a/CompetitionResults/Components/Shared/CompetitionDropdown.razor
+++ b/CompetitionResults/Components/Shared/CompetitionDropdown.razor
@@ -1,15 +1,23 @@
-﻿@using CompetitionResults.Data
+@using CompetitionResults.Data
 @using Microsoft.AspNetCore.Identity
 @using System.Security.Claims
 @inject CompetitionStateService CompetitionState
 @inject CompetitionService CompetitionService
 @inject UserIdStateService UserIdStateService
+@inject IStringLocalizer<SharedResource> L
 @implements IDisposable
 
-<select @onchange="OnSelectionChange" style="width: 400px; margin-top: 15px;">
-    @foreach (var competition in competitions)
+<select value="@CompetitionState.SelectedCompetitionId" @onchange="OnSelectionChange" style="width: 400px; margin-top: 15px;">
+    @if (competitions is null || competitions.Count == 0)
     {
-        <option value="@competition.Id">@competition.Name</option>
+        <option disabled selected>@L["No competitions available"]</option>
+    }
+    else
+    {
+        @foreach (var competition in competitions)
+        {
+            <option value="@competition.Id">@competition.Name</option>
+        }
     }
 </select>
 
@@ -21,8 +29,8 @@
 }
 
 @code {
-    private string errorMessage;
-    private List<Competition> competitions;
+    private string errorMessage = string.Empty;
+    private List<Competition>? competitions;
 
     protected override async Task OnInitializedAsync()
     {
@@ -45,7 +53,6 @@
 
         if (competitions != null && competitions.Count > 0 && CompetitionState.SelectedCompetitionId == 0)
         {
-            // Automatically select the first competition
             CompetitionState.SelectedCompetitionId = competitions[0].Id;
         }
         StateHasChanged();
@@ -56,20 +63,22 @@
         CompetitionService.OnCompetitionsChanged -= LoadData;
     }
 
-    private async void OnSelectionChange(ChangeEventArgs e)
+    private void OnSelectionChange(ChangeEventArgs e)
     {
-        int competitionId = int.Parse(e.Value.ToString());
+        if (!int.TryParse(e.Value?.ToString(), out var competitionId))
+        {
+            errorMessage = L["Invalid competition selection."];
+            return;
+        }
 
-        if (competitions.Any(c => c.Id == competitionId))
+        if (competitions != null && competitions.Any(c => c.Id == competitionId))
         {
             CompetitionState.SelectedCompetitionId = competitionId;
-            errorMessage = string.Empty; // Clear previous error messages if any
+            errorMessage = string.Empty;
         }
         else
         {
-            errorMessage = "Error: Invalid competition selection.";
+            errorMessage = L["Invalid competition selection."];
         }
     }
-
-
 }

--- a/CompetitionResults/Components/Shared/LanguageSelector.razor
+++ b/CompetitionResults/Components/Shared/LanguageSelector.razor
@@ -1,0 +1,47 @@
+@using System
+@using System.Globalization
+@inject NavigationManager NavigationManager
+@inject IStringLocalizer<SharedResource> L
+
+<select class="form-select form-select-sm language-selector" value="@currentCulture" @onchange="OnLanguageChanged">
+    @foreach (var option in supportedCultures)
+    {
+        <option value="@option.Code">@L[option.DisplayName]</option>
+    }
+</select>
+
+@code {
+    private readonly IReadOnlyList<CultureOption> supportedCultures = new[]
+    {
+        new CultureOption("en", "English"),
+        new CultureOption("cs", "Čeština")
+    };
+
+    private string currentCulture = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+
+    private void OnLanguageChanged(ChangeEventArgs args)
+    {
+        var newCulture = args.Value?.ToString();
+        if (string.IsNullOrWhiteSpace(newCulture) || newCulture == currentCulture)
+        {
+            return;
+        }
+
+        currentCulture = newCulture;
+        var relativeUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        if (!relativeUrl.StartsWith('/'))
+        {
+            relativeUrl = $"/{relativeUrl}";
+        }
+
+        if (string.IsNullOrWhiteSpace(relativeUrl) || relativeUrl == "/")
+        {
+            relativeUrl = "/";
+        }
+
+        var encodedReturnUrl = Uri.EscapeDataString(relativeUrl);
+        NavigationManager.NavigateTo($"/culture/set?culture={newCulture}&returnUrl={encodedReturnUrl}", forceLoad: true);
+    }
+
+    private record CultureOption(string Code, string DisplayName);
+}

--- a/CompetitionResults/Components/Shared/LoginDisplay.razor
+++ b/CompetitionResults/Components/Shared/LoginDisplay.razor
@@ -1,14 +1,14 @@
-﻿@implements IDisposable
-
+@implements IDisposable
 @inject NavigationManager NavigationManager
+@inject IStringLocalizer<SharedResource> L
 
 <AuthorizeView>
     <Authorized>
-        <span class="ml-2">&nbsp;&nbsp;User: @context.User.Identity?.Name!</span>
-        <NavLink href="/account/logout" class="nav-link">Log out</NavLink>
+        <span class="ml-2">&nbsp;&nbsp;@L["User"]: @context.User.Identity?.Name!</span>
+        <NavLink href="/account/logout" class="nav-link">@L["Log out"]</NavLink>
     </Authorized>
     <NotAuthorized>
-        <a href="/account/login" class="nav-link">Log in</a>
+        <a href="/account/login" class="nav-link">@L["Log in"]</a>
     </NotAuthorized>
 </AuthorizeView>
 
@@ -32,4 +32,3 @@
         NavigationManager.LocationChanged -= OnLocationChanged;
     }
 }
-

--- a/CompetitionResults/Components/_Imports.razor
+++ b/CompetitionResults/Components/_Imports.razor
@@ -9,3 +9,5 @@
 @using Microsoft.JSInterop
 @using CompetitionResults
 @using CompetitionResults.Components
+@using Microsoft.Extensions.Localization
+@using CompetitionResults.Resources

--- a/CompetitionResults/Controllers/LocalizationController.cs
+++ b/CompetitionResults/Controllers/LocalizationController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace CompetitionResults.Controllers
+{
+    [Route("culture")]
+    public class LocalizationController : Controller
+    {
+        [HttpPost("set")]
+        [HttpGet("set")]
+        public IActionResult SetCulture(string culture, string returnUrl)
+        {
+            if (string.IsNullOrWhiteSpace(returnUrl) || !Url.IsLocalUrl(returnUrl))
+            {
+                returnUrl = Url.Content("~/");
+            }
+
+            Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
+                new CookieOptions
+                {
+                    Expires = DateTimeOffset.UtcNow.AddYears(1)
+                });
+
+            return LocalRedirect(returnUrl);
+        }
+    }
+}

--- a/CompetitionResults/Resources/SharedResource.cs
+++ b/CompetitionResults/Resources/SharedResource.cs
@@ -1,0 +1,9 @@
+namespace CompetitionResults.Resources
+{
+    /// <summary>
+    /// Marker class for shared localization resources.
+    /// </summary>
+    public class SharedResource
+    {
+    }
+}

--- a/CompetitionResults/Resources/SharedResource.cs.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.resx
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="An unhandled error has occurred." xml:space="preserve">
+    <value>Došlo k neočekávané chybě.</value>
+  </data>
+  <data name="Reload" xml:space="preserve">
+    <value>Znovu načíst</value>
+  </data>
+  <data name="Competition Results" xml:space="preserve">
+    <value>Výsledky soutěže</value>
+  </data>
+  <data name="Results" xml:space="preserve">
+    <value>Výsledky</value>
+  </data>
+  <data name="Navigation menu" xml:space="preserve">
+    <value>Navigační nabídka</value>
+  </data>
+  <data name="Home" xml:space="preserve">
+    <value>Domů</value>
+  </data>
+  <data name="Users" xml:space="preserve">
+    <value>Uživatelé</value>
+  </data>
+  <data name="Competitions" xml:space="preserve">
+    <value>Soutěže</value>
+  </data>
+  <data name="Managers" xml:space="preserve">
+    <value>Manažeři</value>
+  </data>
+  <data name="Categories" xml:space="preserve">
+    <value>Kategorie</value>
+  </data>
+  <data name="Disciplines" xml:space="preserve">
+    <value>Disciplíny</value>
+  </data>
+  <data name="Translations" xml:space="preserve">
+    <value>Překlady</value>
+  </data>
+  <data name="Throwers" xml:space="preserve">
+    <value>Závodníci</value>
+  </data>
+  <data name="Scores" xml:space="preserve">
+    <value>Body</value>
+  </data>
+  <data name="Results (S)" xml:space="preserve">
+    <value>Výsledky (S)</value>
+  </data>
+  <data name="Results Static" xml:space="preserve">
+    <value>Statické výsledky</value>
+  </data>
+  <data name="Results (G)" xml:space="preserve">
+    <value>Výsledky (G)</value>
+  </data>
+  <data name="Results by discipline" xml:space="preserve">
+    <value>Výsledky podle disciplín</value>
+  </data>
+  <data name="Results (T)" xml:space="preserve">
+    <value>Výsledky (T)</value>
+  </data>
+  <data name="Results by thrower" xml:space="preserve">
+    <value>Výsledky podle závodníka</value>
+  </data>
+  <data name="Results (X)" xml:space="preserve">
+    <value>Výsledky (X)</value>
+  </data>
+  <data name="Results selection" xml:space="preserve">
+    <value>Výběr výsledků</value>
+  </data>
+  <data name="Results (C)" xml:space="preserve">
+    <value>Výsledky (C)</value>
+  </data>
+  <data name="Results by country" xml:space="preserve">
+    <value>Výsledky podle země</value>
+  </data>
+  <data name="Medals" xml:space="preserve">
+    <value>Medaile</value>
+  </data>
+  <data name="Log out" xml:space="preserve">
+    <value>Odhlásit se</value>
+  </data>
+  <data name="Registration" xml:space="preserve">
+    <value>Registrace</value>
+  </data>
+  <data name="User" xml:space="preserve">
+    <value>Uživatel</value>
+  </data>
+  <data name="Log in" xml:space="preserve">
+    <value>Přihlásit se</value>
+  </data>
+  <data name="Competition Scores" xml:space="preserve">
+    <value>Body soutěže</value>
+  </data>
+  <data name="App to make competition scoring easy and fast." xml:space="preserve">
+    <value>Aplikace pro snadné a rychlé zpracování výsledků soutěže.</value>
+  </data>
+  <data name="Backup all data" xml:space="preserve">
+    <value>Zálohovat všechna data</value>
+  </data>
+  <data name="Clear competition scores" xml:space="preserve">
+    <value>Vymazat výsledky soutěže</value>
+  </data>
+  <data name="Import all data" xml:space="preserve">
+    <value>Importovat všechna data</value>
+  </data>
+  <data name="Backup competition data" xml:space="preserve">
+    <value>Zálohovat data soutěže</value>
+  </data>
+  <data name="Import competition data" xml:space="preserve">
+    <value>Importovat data soutěže</value>
+  </data>
+  <data name="Are you sure you want to clear all results?" xml:space="preserve">
+    <value>Opravdu chcete smazat všechny výsledky?</value>
+  </data>
+  <data name="Generate random scores for all disciplines and throwers?" xml:space="preserve">
+    <value>Vygenerovat náhodné výsledky pro všechny disciplíny a závodníky?</value>
+  </data>
+  <data name="Are you sure you want to clear database?" xml:space="preserve">
+    <value>Opravdu chcete vymazat databázi?</value>
+  </data>
+  <data name="Invalid competition selection." xml:space="preserve">
+    <value>Neplatný výběr soutěže.</value>
+  </data>
+  <data name="No competitions available" xml:space="preserve">
+    <value>Žádné soutěže nejsou k dispozici</value>
+  </data>
+  <data name="English" xml:space="preserve">
+    <value>Angličtina</value>
+  </data>
+  <data name="Čeština" xml:space="preserve">
+    <value>Čeština</value>
+  </data>
+  <data name="Competitions List" xml:space="preserve">
+    <value>Seznam soutěží</value>
+  </data>
+  <data name="Add New Competition" xml:space="preserve">
+    <value>Přidat novou soutěž</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>Načítání...</value>
+  </data>
+  <data name="No competitions found." xml:space="preserve">
+    <value>Žádné soutěže nebyly nalezeny.</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Název</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Popis</value>
+  </data>
+  <data name="Camping" xml:space="preserve">
+    <value>Kempování</value>
+  </data>
+  <data name="T-Shirt" xml:space="preserve">
+    <value>Tričko</value>
+  </data>
+  <data name="T-Shirt Link" xml:space="preserve">
+    <value>Odkaz na tričko</value>
+  </data>
+  <data name="Actions" xml:space="preserve">
+    <value>Akce</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Ano</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>Ne</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Upravit</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Smazat</value>
+  </data>
+  <data name="You're not logged in." xml:space="preserve">
+    <value>Nejste přihlášeni.</value>
+  </data>
+  <data name="Are you sure you want to delete this competition?" xml:space="preserve">
+    <value>Opravdu chcete smazat tuto soutěž?</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- configure ASP.NET localization with English default, Czech alternative, and a controller endpoint for switching cultures
- add shared resource files plus a reusable language selector component and integrate it into the main layout and navigation
- localize the navigation, login display, home page, competitions list, and competition selector with Czech translations

## Testing
- dotnet build *(fails: `command not found: dotnet` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da60fca978832cb9bc75a61a0a9647