### PR TITLE
Fix localization cookie path

### DIFF
--- a/CompetitionResults/Controllers/LocalizationController.cs
+++ b/CompetitionResults/Controllers/LocalizationController.cs
@@ -21,7 +21,8 @@ namespace CompetitionResults.Controllers
                 CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
                 new CookieOptions
                 {
-                    Expires = DateTimeOffset.UtcNow.AddYears(1)
+                    Expires = DateTimeOffset.UtcNow.AddYears(1),
+                    Path = "/"
                 });
 
             return LocalRedirect(returnUrl);


### PR DESCRIPTION
## Summary
- ensure the localization culture cookie applies to the whole site by setting its path to root

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68daa9374df4832cbb378cc847cdd8c5