### PR TITLE
Add Slovak, Russian, French, and Italian localizations

### DIFF
--- a/CompetitionResults/Components/Shared/LanguageSelector.razor
+++ b/CompetitionResults/Components/Shared/LanguageSelector.razor
@@ -14,7 +14,11 @@
     private readonly IReadOnlyList<CultureOption> supportedCultures = new[]
     {
         new CultureOption("en", "English"),
-        new CultureOption("cs", "Čeština")
+        new CultureOption("cs", "Čeština"),
+        new CultureOption("sk", "Slovenčina"),
+        new CultureOption("ru", "Русский"),
+        new CultureOption("fr", "Français"),
+        new CultureOption("it", "Italiano")
     };
 
     private string currentCulture = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;

--- a/CompetitionResults/Program.cs
+++ b/CompetitionResults/Program.cs
@@ -63,7 +63,11 @@ namespace CompetitionResults
             var supportedCultures = new[]
             {
                 new CultureInfo("en"),
-                new CultureInfo("cs")
+                new CultureInfo("cs"),
+                new CultureInfo("sk"),
+                new CultureInfo("ru"),
+                new CultureInfo("fr"),
+                new CultureInfo("it")
             };
 
             builder.Services.Configure<RequestLocalizationOptions>(options =>

--- a/CompetitionResults/Resources/SharedResource.cs.fr.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.fr.resx
@@ -13,192 +13,192 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="An unhandled error has occurred." xml:space="preserve">
-    <value>Došlo k neočekávané chybě.</value>
+    <value>Une erreur non gérée s'est produite.</value>
   </data>
   <data name="Reload" xml:space="preserve">
-    <value>Znovu načíst</value>
+    <value>Recharger</value>
   </data>
   <data name="Competition Results" xml:space="preserve">
-    <value>Výsledky soutěže</value>
+    <value>Résultats de la compétition</value>
   </data>
   <data name="Results" xml:space="preserve">
-    <value>Výsledky</value>
+    <value>Résultats</value>
   </data>
   <data name="Navigation menu" xml:space="preserve">
-    <value>Navigační nabídka</value>
+    <value>Menu de navigation</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>Domů</value>
+    <value>Accueil</value>
   </data>
   <data name="Users" xml:space="preserve">
-    <value>Uživatelé</value>
+    <value>Utilisateurs</value>
   </data>
   <data name="Competitions" xml:space="preserve">
-    <value>Soutěže</value>
+    <value>Compétitions</value>
   </data>
   <data name="Managers" xml:space="preserve">
-    <value>Manažeři</value>
+    <value>Gestionnaires</value>
   </data>
   <data name="Categories" xml:space="preserve">
-    <value>Kategorie</value>
+    <value>Catégories</value>
   </data>
   <data name="Disciplines" xml:space="preserve">
-    <value>Disciplíny</value>
+    <value>Disciplines</value>
   </data>
   <data name="Translations" xml:space="preserve">
-    <value>Překlady</value>
+    <value>Traductions</value>
   </data>
   <data name="Throwers" xml:space="preserve">
-    <value>Závodníci</value>
+    <value>Athlètes</value>
   </data>
   <data name="Scores" xml:space="preserve">
-    <value>Body</value>
+    <value>Scores</value>
   </data>
   <data name="Results (S)" xml:space="preserve">
-    <value>Výsledky (S)</value>
+    <value>Résultats (S)</value>
   </data>
   <data name="Results Static" xml:space="preserve">
-    <value>Statické výsledky</value>
+    <value>Résultats statiques</value>
   </data>
   <data name="Results (G)" xml:space="preserve">
-    <value>Výsledky (G)</value>
+    <value>Résultats (G)</value>
   </data>
   <data name="Results by discipline" xml:space="preserve">
-    <value>Výsledky podle disciplín</value>
+    <value>Résultats par discipline</value>
   </data>
   <data name="Results (T)" xml:space="preserve">
-    <value>Výsledky (T)</value>
+    <value>Résultats (T)</value>
   </data>
   <data name="Results by thrower" xml:space="preserve">
-    <value>Výsledky podle závodníka</value>
+    <value>Résultats par athlète</value>
   </data>
   <data name="Results (X)" xml:space="preserve">
-    <value>Výsledky (X)</value>
+    <value>Résultats (X)</value>
   </data>
   <data name="Results selection" xml:space="preserve">
-    <value>Výběr výsledků</value>
+    <value>Sélection des résultats</value>
   </data>
   <data name="Results (C)" xml:space="preserve">
-    <value>Výsledky (C)</value>
+    <value>Résultats (C)</value>
   </data>
   <data name="Results by country" xml:space="preserve">
-    <value>Výsledky podle země</value>
+    <value>Résultats par pays</value>
   </data>
   <data name="Medals" xml:space="preserve">
-    <value>Medaile</value>
+    <value>Médailles</value>
   </data>
   <data name="Log out" xml:space="preserve">
-    <value>Odhlásit se</value>
+    <value>Se déconnecter</value>
   </data>
   <data name="Registration" xml:space="preserve">
-    <value>Registrace</value>
+    <value>Inscription</value>
   </data>
   <data name="User" xml:space="preserve">
-    <value>Uživatel</value>
+    <value>Utilisateur</value>
   </data>
   <data name="Log in" xml:space="preserve">
-    <value>Přihlásit se</value>
+    <value>Se connecter</value>
   </data>
   <data name="Competition Scores" xml:space="preserve">
-    <value>Body soutěže</value>
+    <value>Scores de la compétition</value>
   </data>
   <data name="App to make competition scoring easy and fast." xml:space="preserve">
-    <value>Aplikace pro snadné a rychlé zpracování výsledků soutěže.</value>
+    <value>Application pour faciliter et accélérer le calcul des résultats d'une compétition.</value>
   </data>
   <data name="Backup all data" xml:space="preserve">
-    <value>Zálohovat všechna data</value>
+    <value>Sauvegarder toutes les données</value>
   </data>
   <data name="Clear competition scores" xml:space="preserve">
-    <value>Vymazat výsledky soutěže</value>
+    <value>Effacer les scores de la compétition</value>
   </data>
   <data name="Import all data" xml:space="preserve">
-    <value>Importovat všechna data</value>
+    <value>Importer toutes les données</value>
   </data>
   <data name="Backup competition data" xml:space="preserve">
-    <value>Zálohovat data soutěže</value>
+    <value>Sauvegarder les données de la compétition</value>
   </data>
   <data name="Import competition data" xml:space="preserve">
-    <value>Importovat data soutěže</value>
+    <value>Importer les données de la compétition</value>
   </data>
   <data name="Are you sure you want to clear all results?" xml:space="preserve">
-    <value>Opravdu chcete smazat všechny výsledky?</value>
+    <value>Êtes-vous sûr de vouloir effacer tous les résultats ?</value>
   </data>
   <data name="Generate random scores for all disciplines and throwers?" xml:space="preserve">
-    <value>Vygenerovat náhodné výsledky pro všechny disciplíny a závodníky?</value>
+    <value>Générer des scores aléatoires pour toutes les disciplines et tous les athlètes ?</value>
   </data>
   <data name="Are you sure you want to clear database?" xml:space="preserve">
-    <value>Opravdu chcete vymazat databázi?</value>
+    <value>Êtes-vous sûr de vouloir effacer la base de données ?</value>
   </data>
   <data name="Invalid competition selection." xml:space="preserve">
-    <value>Neplatný výběr soutěže.</value>
+    <value>Sélection de compétition invalide.</value>
   </data>
   <data name="No competitions available" xml:space="preserve">
-    <value>Žádné soutěže nejsou k dispozici</value>
+    <value>Aucune compétition disponible</value>
   </data>
   <data name="English" xml:space="preserve">
-    <value>Angličtina</value>
+    <value>Anglais</value>
   </data>
   <data name="Čeština" xml:space="preserve">
-    <value>Čeština</value>
+    <value>Tchèque</value>
   </data>
   <data name="Slovenčina" xml:space="preserve">
-    <value>Slovenština</value>
+    <value>Slovaque</value>
   </data>
   <data name="Русский" xml:space="preserve">
-    <value>Ruština</value>
+    <value>Russe</value>
   </data>
   <data name="Français" xml:space="preserve">
-    <value>Francouzština</value>
+    <value>Français</value>
   </data>
   <data name="Italiano" xml:space="preserve">
-    <value>Italština</value>
+    <value>Italien</value>
   </data>
   <data name="Competitions List" xml:space="preserve">
-    <value>Seznam soutěží</value>
+    <value>Liste des compétitions</value>
   </data>
   <data name="Add New Competition" xml:space="preserve">
-    <value>Přidat novou soutěž</value>
+    <value>Ajouter une nouvelle compétition</value>
   </data>
   <data name="Loading..." xml:space="preserve">
-    <value>Načítání...</value>
+    <value>Chargement...</value>
   </data>
   <data name="No competitions found." xml:space="preserve">
-    <value>Žádné soutěže nebyly nalezeny.</value>
+    <value>Aucune compétition trouvée.</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Název</value>
+    <value>Nom</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Popis</value>
+    <value>Description</value>
   </data>
   <data name="Camping" xml:space="preserve">
-    <value>Kempování</value>
+    <value>Camping</value>
   </data>
   <data name="T-Shirt" xml:space="preserve">
-    <value>Tričko</value>
+    <value>T-shirt</value>
   </data>
   <data name="T-Shirt Link" xml:space="preserve">
-    <value>Odkaz na tričko</value>
+    <value>Lien du T-shirt</value>
   </data>
   <data name="Actions" xml:space="preserve">
-    <value>Akce</value>
+    <value>Actions</value>
   </data>
   <data name="Yes" xml:space="preserve">
-    <value>Ano</value>
+    <value>Oui</value>
   </data>
   <data name="No" xml:space="preserve">
-    <value>Ne</value>
+    <value>Non</value>
   </data>
   <data name="Edit" xml:space="preserve">
-    <value>Upravit</value>
+    <value>Modifier</value>
   </data>
   <data name="Delete" xml:space="preserve">
-    <value>Smazat</value>
+    <value>Supprimer</value>
   </data>
   <data name="You're not logged in." xml:space="preserve">
-    <value>Nejste přihlášeni.</value>
+    <value>Vous n'êtes pas connecté.</value>
   </data>
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
-    <value>Opravdu chcete smazat tuto soutěž?</value>
+    <value>Êtes-vous sûr de vouloir supprimer cette compétition ?</value>
   </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.cs.it.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.it.resx
@@ -13,192 +13,192 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="An unhandled error has occurred." xml:space="preserve">
-    <value>Došlo k neočekávané chybě.</value>
+    <value>Si è verificato un errore non gestito.</value>
   </data>
   <data name="Reload" xml:space="preserve">
-    <value>Znovu načíst</value>
+    <value>Ricarica</value>
   </data>
   <data name="Competition Results" xml:space="preserve">
-    <value>Výsledky soutěže</value>
+    <value>Risultati della competizione</value>
   </data>
   <data name="Results" xml:space="preserve">
-    <value>Výsledky</value>
+    <value>Risultati</value>
   </data>
   <data name="Navigation menu" xml:space="preserve">
-    <value>Navigační nabídka</value>
+    <value>Menu di navigazione</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>Domů</value>
+    <value>Home</value>
   </data>
   <data name="Users" xml:space="preserve">
-    <value>Uživatelé</value>
+    <value>Utenti</value>
   </data>
   <data name="Competitions" xml:space="preserve">
-    <value>Soutěže</value>
+    <value>Competizioni</value>
   </data>
   <data name="Managers" xml:space="preserve">
-    <value>Manažeři</value>
+    <value>Manager</value>
   </data>
   <data name="Categories" xml:space="preserve">
-    <value>Kategorie</value>
+    <value>Categorie</value>
   </data>
   <data name="Disciplines" xml:space="preserve">
-    <value>Disciplíny</value>
+    <value>Discipline</value>
   </data>
   <data name="Translations" xml:space="preserve">
-    <value>Překlady</value>
+    <value>Traduzioni</value>
   </data>
   <data name="Throwers" xml:space="preserve">
-    <value>Závodníci</value>
+    <value>Atleti</value>
   </data>
   <data name="Scores" xml:space="preserve">
-    <value>Body</value>
+    <value>Punteggi</value>
   </data>
   <data name="Results (S)" xml:space="preserve">
-    <value>Výsledky (S)</value>
+    <value>Risultati (S)</value>
   </data>
   <data name="Results Static" xml:space="preserve">
-    <value>Statické výsledky</value>
+    <value>Risultati statici</value>
   </data>
   <data name="Results (G)" xml:space="preserve">
-    <value>Výsledky (G)</value>
+    <value>Risultati (G)</value>
   </data>
   <data name="Results by discipline" xml:space="preserve">
-    <value>Výsledky podle disciplín</value>
+    <value>Risultati per disciplina</value>
   </data>
   <data name="Results (T)" xml:space="preserve">
-    <value>Výsledky (T)</value>
+    <value>Risultati (T)</value>
   </data>
   <data name="Results by thrower" xml:space="preserve">
-    <value>Výsledky podle závodníka</value>
+    <value>Risultati per atleta</value>
   </data>
   <data name="Results (X)" xml:space="preserve">
-    <value>Výsledky (X)</value>
+    <value>Risultati (X)</value>
   </data>
   <data name="Results selection" xml:space="preserve">
-    <value>Výběr výsledků</value>
+    <value>Selezione risultati</value>
   </data>
   <data name="Results (C)" xml:space="preserve">
-    <value>Výsledky (C)</value>
+    <value>Risultati (C)</value>
   </data>
   <data name="Results by country" xml:space="preserve">
-    <value>Výsledky podle země</value>
+    <value>Risultati per paese</value>
   </data>
   <data name="Medals" xml:space="preserve">
-    <value>Medaile</value>
+    <value>Medaglie</value>
   </data>
   <data name="Log out" xml:space="preserve">
-    <value>Odhlásit se</value>
+    <value>Disconnetti</value>
   </data>
   <data name="Registration" xml:space="preserve">
-    <value>Registrace</value>
+    <value>Registrazione</value>
   </data>
   <data name="User" xml:space="preserve">
-    <value>Uživatel</value>
+    <value>Utente</value>
   </data>
   <data name="Log in" xml:space="preserve">
-    <value>Přihlásit se</value>
+    <value>Accedi</value>
   </data>
   <data name="Competition Scores" xml:space="preserve">
-    <value>Body soutěže</value>
+    <value>Punteggi della competizione</value>
   </data>
   <data name="App to make competition scoring easy and fast." xml:space="preserve">
-    <value>Aplikace pro snadné a rychlé zpracování výsledků soutěže.</value>
+    <value>Applicazione per rendere la gestione dei punteggi di gara semplice e veloce.</value>
   </data>
   <data name="Backup all data" xml:space="preserve">
-    <value>Zálohovat všechna data</value>
+    <value>Esegui backup di tutti i dati</value>
   </data>
   <data name="Clear competition scores" xml:space="preserve">
-    <value>Vymazat výsledky soutěže</value>
+    <value>Cancella i punteggi della competizione</value>
   </data>
   <data name="Import all data" xml:space="preserve">
-    <value>Importovat všechna data</value>
+    <value>Importa tutti i dati</value>
   </data>
   <data name="Backup competition data" xml:space="preserve">
-    <value>Zálohovat data soutěže</value>
+    <value>Esegui backup dei dati della competizione</value>
   </data>
   <data name="Import competition data" xml:space="preserve">
-    <value>Importovat data soutěže</value>
+    <value>Importa i dati della competizione</value>
   </data>
   <data name="Are you sure you want to clear all results?" xml:space="preserve">
-    <value>Opravdu chcete smazat všechny výsledky?</value>
+    <value>Sei sicuro di voler cancellare tutti i risultati?</value>
   </data>
   <data name="Generate random scores for all disciplines and throwers?" xml:space="preserve">
-    <value>Vygenerovat náhodné výsledky pro všechny disciplíny a závodníky?</value>
+    <value>Generare punteggi casuali per tutte le discipline e gli atleti?</value>
   </data>
   <data name="Are you sure you want to clear database?" xml:space="preserve">
-    <value>Opravdu chcete vymazat databázi?</value>
+    <value>Sei sicuro di voler cancellare il database?</value>
   </data>
   <data name="Invalid competition selection." xml:space="preserve">
-    <value>Neplatný výběr soutěže.</value>
+    <value>Selezione della competizione non valida.</value>
   </data>
   <data name="No competitions available" xml:space="preserve">
-    <value>Žádné soutěže nejsou k dispozici</value>
+    <value>Nessuna competizione disponibile</value>
   </data>
   <data name="English" xml:space="preserve">
-    <value>Angličtina</value>
+    <value>Inglese</value>
   </data>
   <data name="Čeština" xml:space="preserve">
-    <value>Čeština</value>
+    <value>Ceco</value>
   </data>
   <data name="Slovenčina" xml:space="preserve">
-    <value>Slovenština</value>
+    <value>Slovacco</value>
   </data>
   <data name="Русский" xml:space="preserve">
-    <value>Ruština</value>
+    <value>Russo</value>
   </data>
   <data name="Français" xml:space="preserve">
-    <value>Francouzština</value>
+    <value>Francese</value>
   </data>
   <data name="Italiano" xml:space="preserve">
-    <value>Italština</value>
+    <value>Italiano</value>
   </data>
   <data name="Competitions List" xml:space="preserve">
-    <value>Seznam soutěží</value>
+    <value>Elenco competizioni</value>
   </data>
   <data name="Add New Competition" xml:space="preserve">
-    <value>Přidat novou soutěž</value>
+    <value>Aggiungi nuova competizione</value>
   </data>
   <data name="Loading..." xml:space="preserve">
-    <value>Načítání...</value>
+    <value>Caricamento...</value>
   </data>
   <data name="No competitions found." xml:space="preserve">
-    <value>Žádné soutěže nebyly nalezeny.</value>
+    <value>Nessuna competizione trovata.</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Název</value>
+    <value>Nome</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Popis</value>
+    <value>Descrizione</value>
   </data>
   <data name="Camping" xml:space="preserve">
-    <value>Kempování</value>
+    <value>Campeggio</value>
   </data>
   <data name="T-Shirt" xml:space="preserve">
-    <value>Tričko</value>
+    <value>Maglietta</value>
   </data>
   <data name="T-Shirt Link" xml:space="preserve">
-    <value>Odkaz na tričko</value>
+    <value>Link alla maglietta</value>
   </data>
   <data name="Actions" xml:space="preserve">
-    <value>Akce</value>
+    <value>Azioni</value>
   </data>
   <data name="Yes" xml:space="preserve">
-    <value>Ano</value>
+    <value>Sì</value>
   </data>
   <data name="No" xml:space="preserve">
-    <value>Ne</value>
+    <value>No</value>
   </data>
   <data name="Edit" xml:space="preserve">
-    <value>Upravit</value>
+    <value>Modifica</value>
   </data>
   <data name="Delete" xml:space="preserve">
-    <value>Smazat</value>
+    <value>Elimina</value>
   </data>
   <data name="You're not logged in." xml:space="preserve">
-    <value>Nejste přihlášeni.</value>
+    <value>Non hai effettuato l'accesso.</value>
   </data>
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
-    <value>Opravdu chcete smazat tuto soutěž?</value>
+    <value>Sei sicuro di voler eliminare questa competizione?</value>
   </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.cs.ru.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.ru.resx
@@ -13,192 +13,192 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="An unhandled error has occurred." xml:space="preserve">
-    <value>Došlo k neočekávané chybě.</value>
+    <value>Произошла необработанная ошибка.</value>
   </data>
   <data name="Reload" xml:space="preserve">
-    <value>Znovu načíst</value>
+    <value>Перезагрузить</value>
   </data>
   <data name="Competition Results" xml:space="preserve">
-    <value>Výsledky soutěže</value>
+    <value>Результаты соревнований</value>
   </data>
   <data name="Results" xml:space="preserve">
-    <value>Výsledky</value>
+    <value>Результаты</value>
   </data>
   <data name="Navigation menu" xml:space="preserve">
-    <value>Navigační nabídka</value>
+    <value>Меню навигации</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>Domů</value>
+    <value>Главная</value>
   </data>
   <data name="Users" xml:space="preserve">
-    <value>Uživatelé</value>
+    <value>Пользователи</value>
   </data>
   <data name="Competitions" xml:space="preserve">
-    <value>Soutěže</value>
+    <value>Соревнования</value>
   </data>
   <data name="Managers" xml:space="preserve">
-    <value>Manažeři</value>
+    <value>Менеджеры</value>
   </data>
   <data name="Categories" xml:space="preserve">
-    <value>Kategorie</value>
+    <value>Категории</value>
   </data>
   <data name="Disciplines" xml:space="preserve">
-    <value>Disciplíny</value>
+    <value>Дисциплины</value>
   </data>
   <data name="Translations" xml:space="preserve">
-    <value>Překlady</value>
+    <value>Переводы</value>
   </data>
   <data name="Throwers" xml:space="preserve">
-    <value>Závodníci</value>
+    <value>Участники</value>
   </data>
   <data name="Scores" xml:space="preserve">
-    <value>Body</value>
+    <value>Очки</value>
   </data>
   <data name="Results (S)" xml:space="preserve">
-    <value>Výsledky (S)</value>
+    <value>Результаты (S)</value>
   </data>
   <data name="Results Static" xml:space="preserve">
-    <value>Statické výsledky</value>
+    <value>Статические результаты</value>
   </data>
   <data name="Results (G)" xml:space="preserve">
-    <value>Výsledky (G)</value>
+    <value>Результаты (G)</value>
   </data>
   <data name="Results by discipline" xml:space="preserve">
-    <value>Výsledky podle disciplín</value>
+    <value>Результаты по дисциплинам</value>
   </data>
   <data name="Results (T)" xml:space="preserve">
-    <value>Výsledky (T)</value>
+    <value>Результаты (T)</value>
   </data>
   <data name="Results by thrower" xml:space="preserve">
-    <value>Výsledky podle závodníka</value>
+    <value>Результаты по участникам</value>
   </data>
   <data name="Results (X)" xml:space="preserve">
-    <value>Výsledky (X)</value>
+    <value>Результаты (X)</value>
   </data>
   <data name="Results selection" xml:space="preserve">
-    <value>Výběr výsledků</value>
+    <value>Выбор результатов</value>
   </data>
   <data name="Results (C)" xml:space="preserve">
-    <value>Výsledky (C)</value>
+    <value>Результаты (C)</value>
   </data>
   <data name="Results by country" xml:space="preserve">
-    <value>Výsledky podle země</value>
+    <value>Результаты по странам</value>
   </data>
   <data name="Medals" xml:space="preserve">
-    <value>Medaile</value>
+    <value>Медали</value>
   </data>
   <data name="Log out" xml:space="preserve">
-    <value>Odhlásit se</value>
+    <value>Выйти</value>
   </data>
   <data name="Registration" xml:space="preserve">
-    <value>Registrace</value>
+    <value>Регистрация</value>
   </data>
   <data name="User" xml:space="preserve">
-    <value>Uživatel</value>
+    <value>Пользователь</value>
   </data>
   <data name="Log in" xml:space="preserve">
-    <value>Přihlásit se</value>
+    <value>Войти</value>
   </data>
   <data name="Competition Scores" xml:space="preserve">
-    <value>Body soutěže</value>
+    <value>Очки соревнования</value>
   </data>
   <data name="App to make competition scoring easy and fast." xml:space="preserve">
-    <value>Aplikace pro snadné a rychlé zpracování výsledků soutěže.</value>
+    <value>Приложение для быстрого и простого подсчёта результатов соревнований.</value>
   </data>
   <data name="Backup all data" xml:space="preserve">
-    <value>Zálohovat všechna data</value>
+    <value>Резервное копирование всех данных</value>
   </data>
   <data name="Clear competition scores" xml:space="preserve">
-    <value>Vymazat výsledky soutěže</value>
+    <value>Очистить результаты соревнования</value>
   </data>
   <data name="Import all data" xml:space="preserve">
-    <value>Importovat všechna data</value>
+    <value>Импортировать все данные</value>
   </data>
   <data name="Backup competition data" xml:space="preserve">
-    <value>Zálohovat data soutěže</value>
+    <value>Резервное копирование данных соревнования</value>
   </data>
   <data name="Import competition data" xml:space="preserve">
-    <value>Importovat data soutěže</value>
+    <value>Импортировать данные соревнования</value>
   </data>
   <data name="Are you sure you want to clear all results?" xml:space="preserve">
-    <value>Opravdu chcete smazat všechny výsledky?</value>
+    <value>Вы уверены, что хотите очистить все результаты?</value>
   </data>
   <data name="Generate random scores for all disciplines and throwers?" xml:space="preserve">
-    <value>Vygenerovat náhodné výsledky pro všechny disciplíny a závodníky?</value>
+    <value>Сгенерировать случайные очки для всех дисциплин и участников?</value>
   </data>
   <data name="Are you sure you want to clear database?" xml:space="preserve">
-    <value>Opravdu chcete vymazat databázi?</value>
+    <value>Вы уверены, что хотите очистить базу данных?</value>
   </data>
   <data name="Invalid competition selection." xml:space="preserve">
-    <value>Neplatný výběr soutěže.</value>
+    <value>Неверный выбор соревнования.</value>
   </data>
   <data name="No competitions available" xml:space="preserve">
-    <value>Žádné soutěže nejsou k dispozici</value>
+    <value>Соревнования недоступны</value>
   </data>
   <data name="English" xml:space="preserve">
-    <value>Angličtina</value>
+    <value>Английский</value>
   </data>
   <data name="Čeština" xml:space="preserve">
-    <value>Čeština</value>
+    <value>Чешский</value>
   </data>
   <data name="Slovenčina" xml:space="preserve">
-    <value>Slovenština</value>
+    <value>Словацкий</value>
   </data>
   <data name="Русский" xml:space="preserve">
-    <value>Ruština</value>
+    <value>Русский</value>
   </data>
   <data name="Français" xml:space="preserve">
-    <value>Francouzština</value>
+    <value>Французский</value>
   </data>
   <data name="Italiano" xml:space="preserve">
-    <value>Italština</value>
+    <value>Итальянский</value>
   </data>
   <data name="Competitions List" xml:space="preserve">
-    <value>Seznam soutěží</value>
+    <value>Список соревнований</value>
   </data>
   <data name="Add New Competition" xml:space="preserve">
-    <value>Přidat novou soutěž</value>
+    <value>Добавить новое соревнование</value>
   </data>
   <data name="Loading..." xml:space="preserve">
-    <value>Načítání...</value>
+    <value>Загрузка...</value>
   </data>
   <data name="No competitions found." xml:space="preserve">
-    <value>Žádné soutěže nebyly nalezeny.</value>
+    <value>Соревнования не найдены.</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Název</value>
+    <value>Название</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Popis</value>
+    <value>Описание</value>
   </data>
   <data name="Camping" xml:space="preserve">
-    <value>Kempování</value>
+    <value>Кемпинг</value>
   </data>
   <data name="T-Shirt" xml:space="preserve">
-    <value>Tričko</value>
+    <value>Футболка</value>
   </data>
   <data name="T-Shirt Link" xml:space="preserve">
-    <value>Odkaz na tričko</value>
+    <value>Ссылка на футболку</value>
   </data>
   <data name="Actions" xml:space="preserve">
-    <value>Akce</value>
+    <value>Действия</value>
   </data>
   <data name="Yes" xml:space="preserve">
-    <value>Ano</value>
+    <value>Да</value>
   </data>
   <data name="No" xml:space="preserve">
-    <value>Ne</value>
+    <value>Нет</value>
   </data>
   <data name="Edit" xml:space="preserve">
-    <value>Upravit</value>
+    <value>Редактировать</value>
   </data>
   <data name="Delete" xml:space="preserve">
-    <value>Smazat</value>
+    <value>Удалить</value>
   </data>
   <data name="You're not logged in." xml:space="preserve">
-    <value>Nejste přihlášeni.</value>
+    <value>Вы не вошли в систему.</value>
   </data>
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
-    <value>Opravdu chcete smazat tuto soutěž?</value>
+    <value>Вы уверены, что хотите удалить это соревнование?</value>
   </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.cs.sk.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.sk.resx
@@ -13,43 +13,43 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="An unhandled error has occurred." xml:space="preserve">
-    <value>Došlo k neočekávané chybě.</value>
+    <value>Došlo k neošetrenej chybe.</value>
   </data>
   <data name="Reload" xml:space="preserve">
-    <value>Znovu načíst</value>
+    <value>Znova načítať</value>
   </data>
   <data name="Competition Results" xml:space="preserve">
-    <value>Výsledky soutěže</value>
+    <value>Výsledky súťaže</value>
   </data>
   <data name="Results" xml:space="preserve">
     <value>Výsledky</value>
   </data>
   <data name="Navigation menu" xml:space="preserve">
-    <value>Navigační nabídka</value>
+    <value>Navigačné menu</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>Domů</value>
+    <value>Domov</value>
   </data>
   <data name="Users" xml:space="preserve">
-    <value>Uživatelé</value>
+    <value>Používatelia</value>
   </data>
   <data name="Competitions" xml:space="preserve">
-    <value>Soutěže</value>
+    <value>Súťaže</value>
   </data>
   <data name="Managers" xml:space="preserve">
-    <value>Manažeři</value>
+    <value>Manažéri</value>
   </data>
   <data name="Categories" xml:space="preserve">
-    <value>Kategorie</value>
+    <value>Kategórie</value>
   </data>
   <data name="Disciplines" xml:space="preserve">
     <value>Disciplíny</value>
   </data>
   <data name="Translations" xml:space="preserve">
-    <value>Překlady</value>
+    <value>Preklady</value>
   </data>
   <data name="Throwers" xml:space="preserve">
-    <value>Závodníci</value>
+    <value>Pretekári</value>
   </data>
   <data name="Scores" xml:space="preserve">
     <value>Body</value>
@@ -64,76 +64,76 @@
     <value>Výsledky (G)</value>
   </data>
   <data name="Results by discipline" xml:space="preserve">
-    <value>Výsledky podle disciplín</value>
+    <value>Výsledky podľa disciplíny</value>
   </data>
   <data name="Results (T)" xml:space="preserve">
     <value>Výsledky (T)</value>
   </data>
   <data name="Results by thrower" xml:space="preserve">
-    <value>Výsledky podle závodníka</value>
+    <value>Výsledky podľa pretekára</value>
   </data>
   <data name="Results (X)" xml:space="preserve">
     <value>Výsledky (X)</value>
   </data>
   <data name="Results selection" xml:space="preserve">
-    <value>Výběr výsledků</value>
+    <value>Výber výsledkov</value>
   </data>
   <data name="Results (C)" xml:space="preserve">
     <value>Výsledky (C)</value>
   </data>
   <data name="Results by country" xml:space="preserve">
-    <value>Výsledky podle země</value>
+    <value>Výsledky podľa krajiny</value>
   </data>
   <data name="Medals" xml:space="preserve">
-    <value>Medaile</value>
+    <value>Medaily</value>
   </data>
   <data name="Log out" xml:space="preserve">
-    <value>Odhlásit se</value>
+    <value>Odhlásiť sa</value>
   </data>
   <data name="Registration" xml:space="preserve">
-    <value>Registrace</value>
+    <value>Registrácia</value>
   </data>
   <data name="User" xml:space="preserve">
-    <value>Uživatel</value>
+    <value>Používateľ</value>
   </data>
   <data name="Log in" xml:space="preserve">
-    <value>Přihlásit se</value>
+    <value>Prihlásiť sa</value>
   </data>
   <data name="Competition Scores" xml:space="preserve">
-    <value>Body soutěže</value>
+    <value>Body súťaže</value>
   </data>
   <data name="App to make competition scoring easy and fast." xml:space="preserve">
-    <value>Aplikace pro snadné a rychlé zpracování výsledků soutěže.</value>
+    <value>Aplikácia na jednoduché a rýchle vyhodnotenie súťaže.</value>
   </data>
   <data name="Backup all data" xml:space="preserve">
-    <value>Zálohovat všechna data</value>
+    <value>Zálohovať všetky dáta</value>
   </data>
   <data name="Clear competition scores" xml:space="preserve">
-    <value>Vymazat výsledky soutěže</value>
+    <value>Vymazať výsledky súťaže</value>
   </data>
   <data name="Import all data" xml:space="preserve">
-    <value>Importovat všechna data</value>
+    <value>Importovať všetky dáta</value>
   </data>
   <data name="Backup competition data" xml:space="preserve">
-    <value>Zálohovat data soutěže</value>
+    <value>Zálohovať dáta súťaže</value>
   </data>
   <data name="Import competition data" xml:space="preserve">
-    <value>Importovat data soutěže</value>
+    <value>Importovať dáta súťaže</value>
   </data>
   <data name="Are you sure you want to clear all results?" xml:space="preserve">
-    <value>Opravdu chcete smazat všechny výsledky?</value>
+    <value>Naozaj chcete vymazať všetky výsledky?</value>
   </data>
   <data name="Generate random scores for all disciplines and throwers?" xml:space="preserve">
-    <value>Vygenerovat náhodné výsledky pro všechny disciplíny a závodníky?</value>
+    <value>Vygenerovať náhodné body pre všetky disciplíny a pretekárov?</value>
   </data>
   <data name="Are you sure you want to clear database?" xml:space="preserve">
-    <value>Opravdu chcete vymazat databázi?</value>
+    <value>Naozaj chcete vymazať databázu?</value>
   </data>
   <data name="Invalid competition selection." xml:space="preserve">
-    <value>Neplatný výběr soutěže.</value>
+    <value>Neplatný výber súťaže.</value>
   </data>
   <data name="No competitions available" xml:space="preserve">
-    <value>Žádné soutěže nejsou k dispozici</value>
+    <value>Žiadne súťaže nie sú k dispozícii</value>
   </data>
   <data name="English" xml:space="preserve">
     <value>Angličtina</value>
@@ -142,37 +142,37 @@
     <value>Čeština</value>
   </data>
   <data name="Slovenčina" xml:space="preserve">
-    <value>Slovenština</value>
+    <value>Slovenčina</value>
   </data>
   <data name="Русский" xml:space="preserve">
     <value>Ruština</value>
   </data>
   <data name="Français" xml:space="preserve">
-    <value>Francouzština</value>
+    <value>Francúzština</value>
   </data>
   <data name="Italiano" xml:space="preserve">
-    <value>Italština</value>
+    <value>Taliančina</value>
   </data>
   <data name="Competitions List" xml:space="preserve">
-    <value>Seznam soutěží</value>
+    <value>Zoznam súťaží</value>
   </data>
   <data name="Add New Competition" xml:space="preserve">
-    <value>Přidat novou soutěž</value>
+    <value>Pridať novú súťaž</value>
   </data>
   <data name="Loading..." xml:space="preserve">
-    <value>Načítání...</value>
+    <value>Načítava sa...</value>
   </data>
   <data name="No competitions found." xml:space="preserve">
-    <value>Žádné soutěže nebyly nalezeny.</value>
+    <value>Nenašli sa žiadne súťaže.</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Název</value>
+    <value>Názov</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Popis</value>
+    <value>Opis</value>
   </data>
   <data name="Camping" xml:space="preserve">
-    <value>Kempování</value>
+    <value>Kempovanie</value>
   </data>
   <data name="T-Shirt" xml:space="preserve">
     <value>Tričko</value>
@@ -181,24 +181,24 @@
     <value>Odkaz na tričko</value>
   </data>
   <data name="Actions" xml:space="preserve">
-    <value>Akce</value>
+    <value>Akcie</value>
   </data>
   <data name="Yes" xml:space="preserve">
-    <value>Ano</value>
+    <value>Áno</value>
   </data>
   <data name="No" xml:space="preserve">
-    <value>Ne</value>
+    <value>Nie</value>
   </data>
   <data name="Edit" xml:space="preserve">
-    <value>Upravit</value>
+    <value>Upraviť</value>
   </data>
   <data name="Delete" xml:space="preserve">
-    <value>Smazat</value>
+    <value>Vymazať</value>
   </data>
   <data name="You're not logged in." xml:space="preserve">
-    <value>Nejste přihlášeni.</value>
+    <value>Nie ste prihlásení.</value>
   </data>
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
-    <value>Opravdu chcete smazat tuto soutěž?</value>
+    <value>Naozaj chcete vymazať túto súťaž?</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- add localized resource files for Slovak, Russian, French, and Italian
- register the new cultures and expose them from the language selector

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dab396ace8832ca5e3dbeba66b3d64