### PR TITLE
Localize UI strings in management components

### DIFF
--- a/CompetitionResults/Components/Pages/CategoriesList.razor
+++ b/CompetitionResults/Components/Pages/CategoriesList.razor
@@ -5,26 +5,27 @@
 @inject CompetitionStateService CompetitionState
 @implements IDisposable
 @inject IJSRuntime JSRuntime
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Categories List</h3>
+<h3>@L["Categories List"]</h3>
 
 <AuthorizeView Roles="Admin, Manager">
-	<Authorized>
-<button @onclick="AddNew">Add New Category</button>
+        <Authorized>
+<button @onclick="AddNew">@L["Add New Category"]</button>
 
 <CategoryEditModal @ref="categoryEditModal" OnClose="HandleModalClose" Category="currentCategory" OnFormSubmit="HandleFormSubmit" />
 
 @if (categories == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else
 {
     <table class="table">
         <thead>
             <tr>
-                <th>Name</th>
-                <th>Actions</th>
+                <th>@L["Name"]</th>
+                <th>@L["Actions"]</th>
             </tr>
         </thead>
         <tbody>
@@ -33,8 +34,8 @@ else
                 <tr>
                     <td>@category.Name</td>
                     <td>
-                        <button @onclick="() => EditCategory(category)">Edit</button>
-                        <button @onclick="() => DeleteCategory(category.Id)">Delete</button>
+                        <button @onclick="() => EditCategory(category)">@L["Edit"]</button>
+                        <button @onclick="() => DeleteCategory(category.Id)">@L["Delete"]</button>
                     </td>
                 </tr>
             }
@@ -43,7 +44,7 @@ else
 }
     </Authorized>
     <NotAuthorized>
-        <p>You're not loggged in.</p>
+        <p>@L["You're not logged in."]</p>
     </NotAuthorized>
 </AuthorizeView>
 
@@ -85,7 +86,7 @@ else
 
     private async Task DeleteCategory(int categoryId)
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete this category?");
+        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to delete this category?"]);
         if (confirmed)
         {
             await CategoryService.DeleteCategoryAsync(categoryId);

--- a/CompetitionResults/Components/Pages/DisciplinesList.razor
+++ b/CompetitionResults/Components/Pages/DisciplinesList.razor
@@ -5,29 +5,30 @@
 @inject CompetitionStateService CompetitionState
 @implements IDisposable
 @inject IJSRuntime JSRuntime
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Disciplines List</h3>
+<h3>@L["Disciplines List"]</h3>
 <AuthorizeView Roles="Admin, Manager">
-	<Authorized>
+        <Authorized>
 
-<button @onclick="AddNew">Add New Discipline</button>
+<button @onclick="AddNew">@L["Add New Discipline"]</button>
 
 <DisciplineEditModal @ref="disciplineEditModal" OnClose="HandleModalClose" Discipline="currentDiscipline" OnFormSubmit="HandleFormSubmit" />
 
 @if (disciplines == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else
 {
     <table class="table">
         <thead>
             <tr>
-                <th>Name</th>
-                <th>Is Divided To Categories</th>
-                <th>Has Positions Instead of Points</th>
-                <th>Has Decimal Points</th>
-                <th>Actions</th>
+                <th>@L["Name"]</th>
+                <th>@L["Is Divided To Categories"]</th>
+                <th>@L["Has Positions Instead of Points"]</th>
+                <th>@L["Has Decimal Points"]</th>
+                <th>@L["Actions"]</th>
             </tr>
         </thead>
         <tbody>
@@ -35,12 +36,12 @@ else
             {
                 <tr>
                     <td>@discipline.Name</td>
-                            <td>@(discipline.IsDividedToCategories ? "Yes" : "No")</td>
-                            <td>@(discipline.HasPositionsInsteadPoints ? "Yes" : "No")</td>
-                            <td>@(discipline.HasDecimalPoints ? "Yes" : "No")</td>
+                            <td>@(discipline.IsDividedToCategories ? L["Yes"] : L["No"])</td>
+                            <td>@(discipline.HasPositionsInsteadPoints ? L["Yes"] : L["No"])</td>
+                            <td>@(discipline.HasDecimalPoints ? L["Yes"] : L["No"])</td>
                     <td>
-                        <button @onclick="() => EditDiscipline(discipline)">Edit</button>
-                        <button @onclick="() => DeleteDiscipline(discipline.Id)">Delete</button>
+                        <button @onclick="() => EditDiscipline(discipline)">@L["Edit"]</button>
+                        <button @onclick="() => DeleteDiscipline(discipline.Id)">@L["Delete"]</button>
                     </td>
                 </tr>
             }
@@ -50,7 +51,7 @@ else
 
     </Authorized>
     <NotAuthorized>
-        <p>You're not loggged in.</p>
+        <p>@L["You're not logged in."]</p>
     </NotAuthorized>
 </AuthorizeView>
 
@@ -92,7 +93,7 @@ else
 
     private async Task DeleteDiscipline(int disciplineId)
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete this discipline?");
+        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to delete this discipline?"]);
         if (confirmed)
         {
             await DisciplineService.DeleteDisciplineAsync(disciplineId);

--- a/CompetitionResults/Components/Pages/Managers.razor
+++ b/CompetitionResults/Components/Pages/Managers.razor
@@ -7,16 +7,17 @@
 @inject UserManager<ApplicationUser> UserManager
 @inject RoleManager<IdentityRole> RoleManager
 @inject UserIdStateService UserIdStateService
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Competition Manager Assignments</h3>
+<h3>@L["Competition Manager Assignments"]</h3>
 
 <AuthorizeView Roles="Admin,Manager">
     <Authorized>
         <div class="row mb-3">
             <div class="col-md-4">
-                <label>Select manager:</label>
+                <label>@L["Select manager:"]</label>
                 <select class="form-control" @onchange="OnUserChanged">
-                    <option value="">-- Select Manager --</option>
+                    <option value="">@L["-- Select Manager --"]</option>
                     @foreach (var user in users)
                     {
                         <option value="@user.Id" selected="@(selectedUser?.Id == user.Id)">@user.UserName</option>
@@ -30,8 +31,8 @@
             <table class="table">
                 <thead>
                     <tr>
-                        <th>Competition</th>
-                        <th class="text-center">Assigned</th>
+                        <th>@L["Competition"]</th>
+                        <th class="text-center">@L["Assigned"]</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/CompetitionResults/Components/Pages/ThrowersList.razor
+++ b/CompetitionResults/Components/Pages/ThrowersList.razor
@@ -7,44 +7,45 @@
 @inject CompetitionService CompetitionService
 @implements IDisposable
 @inject IJSRuntime JSRuntime
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Throwers List</h3>
+<h3>@L["Throwers List"]</h3>
 <AuthorizeView Roles="Admin, Manager">
-	<Authorized>
+        <Authorized>
 
-		<button @onclick="AddNew">Add New Thrower</button>
-		<button @onclick="SendEmailsToUnpaid">Send Emails to Unpaid Throwers</button>
-        <button @onclick="OpenGeneralEmailModal">Send Emails</button>
+                <button @onclick="AddNew">@L["Add New Thrower"]</button>
+                <button @onclick="SendEmailsToUnpaid">@L["Send Emails to Unpaid Throwers"]</button>
+        <button @onclick="OpenGeneralEmailModal">@L["Send Emails"]</button>
 
                 <GeneralEmailModal @ref="generalEmailModal" OnSend="HandleSendGeneralEmails" />
 
-		<ThrowerEditModal @ref="throwerEditModal" OnClose="HandleModalClose" Thrower="selectedThrower" OnFormSubmit="HandleFormSubmit" />
+                <ThrowerEditModal @ref="throwerEditModal" OnClose="HandleModalClose" Thrower="selectedThrower" OnFormSubmit="HandleFormSubmit" />
 
-		@if (throwers == null)
-		{
-			<p><em>Loading...</em></p>
-		}
-		else
-		{
-			<table class="table">
-				<thead>
-					<tr>
-						<th>#</th>
-						<th>Name</th>
-						<th>Surname</th>
-						<th>Nickname</th>
-						<th>Nationality</th>
-						<th>Flag</th>
-						<th>Club Name</th>
-						<th>Email</th>
-						<th>Camping on site</th>
-						<th>Want T-Shirt (size)</th>
-						<th>Is paid (amount)</th>
-						<th>To Be Paid</th>
-						<th>Note</th>
-						<th>Actions</th>
-					</tr>
-				</thead>
+                @if (throwers == null)
+                {
+                        <p><em>@L["Loading..."]</em></p>
+                }
+                else
+                {
+                        <table class="table">
+                                <thead>
+                                        <tr>
+                                                <th>#</th>
+                                                <th>@L["Name"]</th>
+                                                <th>@L["Surname"]</th>
+                                                <th>@L["Nickname"]</th>
+                                                <th>@L["Nationality"]</th>
+                                                <th>@L["Flag"]</th>
+                                                <th>@L["Club Name"]</th>
+                                                <th>@L["Email"]</th>
+                                                <th>@L["Camping on site"]</th>
+                                                <th>@L["Want T-Shirt (size)"]</th>
+                                                <th>@L["Is paid (amount)"]</th>
+                                                <th>@L["To Be Paid"]</th>
+                                                <th>@L["Note"]</th>
+                                                <th>@L["Actions"]</th>
+                                        </tr>
+                                </thead>
 				<tbody>
 					@foreach (var thrower in throwers.OrderBy(t => t.StartingNumber))
 					{
@@ -66,9 +67,9 @@
 							</td>
 							<td>@thrower.ClubName</td>
 							<td>@thrower.Email</td>
-							<td>@(thrower.IsCampingOnSite ? "Yes" : "No")</td>
-							<td>@(thrower.WantTShirt ? "Yes" : "No") (@thrower.TShirtSize)</td>
-							<td style="background-color: @(!thrower.PaymentDone ? "red" : "white");">@(thrower.PaymentDone ? "Yes" : "No") (@thrower.Payment) </td>
+                                                        <td>@(thrower.IsCampingOnSite ? L["Yes"] : L["No"])</td>
+                                                        <td>@(thrower.WantTShirt ? L["Yes"] : L["No"]) (@thrower.TShirtSize)</td>
+                                                        <td style="background-color: @(!thrower.PaymentDone ? "red" : "white");">@(thrower.PaymentDone ? L["Yes"] : L["No"]) (@thrower.Payment) </td>
 							<td>
 								@{
 									var displayedDifference = difference < 0 ? 0 : difference;
@@ -87,13 +88,13 @@
 							</td>
 
 							<td>
-								<button @onclick="() => SendEmail(thrower)">Send reg. e-mail</button>
-								@if (!thrower.PaymentDone)
-								{
-									<button @onclick="() => SendUnpaidEmail(thrower)">Send unpaid e-mail</button>
-								}
-								<button @onclick="() => EditThrower(thrower)">Edit</button>
-								<button @onclick="() => DeleteThrower(thrower.Id)">Delete</button>
+                                                                <button @onclick="() => SendEmail(thrower)">@L["Send registration email"]</button>
+                                                                @if (!thrower.PaymentDone)
+                                                                {
+                                                                        <button @onclick="() => SendUnpaidEmail(thrower)">@L["Send unpaid email"]</button>
+                                                                }
+                                                                <button @onclick="() => EditThrower(thrower)">@L["Edit"]</button>
+                                                                <button @onclick="() => DeleteThrower(thrower.Id)">@L["Delete"]</button>
 							</td>
 						</tr>
 					}
@@ -102,59 +103,59 @@
 
 			<div style="margin-top: 20px;">
 				<p>
-					<h4>Total throwers: @throwersCount</h4>
-					<h4>Total payments: @paymentsCount</h4>
-				</p>
-				<p>
-					<h4>Total countries: @countryCount</h4>
-					@foreach (var country in countryFlags)
-					{
-						var flagUrl = $"https://flagcdn.com/32x24/{country}.png";
-						<img src="@flagUrl" alt="@country" title="@country" style="height:20px; width:30px; margin-left: 5px;" />
-					}
-				</p>
+                                        <h4>@L["Total throwers: {0}", throwersCount]</h4>
+                                        <h4>@L["Total payments: {0}", paymentsCount]</h4>
+                                </p>
+                                <p>
+                                        <h4>@L["Total countries: {0}", countryCount]</h4>
+                                        @foreach (var country in countryFlags)
+                                        {
+                                                var flagUrl = $"https://flagcdn.com/32x24/{country}.png";
+                                                <img src="@flagUrl" alt="@country" title="@country" style="height:20px; width:30px; margin-left: 5px;" />
+                                        }
+                                </p>
 
-				<h4>Categories:</h4>
-				<ul>
-					@foreach (var category in categoriesDict)
-					{
-						<li>@category.Key: @category.Value</li>
-					}
-				</ul>
+                                <h4>@L["Categories:"]</h4>
+                                <ul>
+                                        @foreach (var category in categoriesDict)
+                                        {
+                                                <li>@category.Key: @category.Value</li>
+                                        }
+                                </ul>
 
-				<p>
-					<h4>Total campers: @campersCount</h4>
-				</p>
+                                <p>
+                                        <h4>@L["Total campers: {0}", campersCount]</h4>
+                                </p>
 
-				<h4>T-shirts:</h4>
-				<ul>
-					@foreach (var tshirt in tshirtDict.OrderBy(t => t.Key))
-					{
-						<li>@tshirt.Key: @tshirt.Value</li>
-					}
-				</ul>
+                                <h4>@L["T-shirts:"]</h4>
+                                <ul>
+                                        @foreach (var tshirt in tshirtDict.OrderBy(t => t.Key))
+                                        {
+                                                <li>@tshirt.Key: @tshirt.Value</li>
+                                        }
+                                </ul>
 
-				<p>
-					<h4>Throwers by country:</h4>
-					<ul>
-						@foreach (var country in countryParticipants.OrderByDescending(p => p.Value))
-						{
-							var flagUrl = $"https://flagcdn.com/32x24/{country}.png";
+                                <p>
+                                        <h4>@L["Throwers by country:"]</h4>
+                                        <ul>
+                                                @foreach (var country in countryParticipants.OrderByDescending(p => p.Value))
+                                                {
+                                                        var flagUrl = $"https://flagcdn.com/32x24/{country}.png";
 							<li>@country.Key: @country.Value</li>
 						}
 					</ul>
 				</p>
 
 				<p>
-					<h4>Total missing payments above tolerance: <span style="color:red; font-weight:bold;">@($"{totalDifference:0.00}")</span></h4>
-				</p>
-			</div>
-		}
+                                        <h4>@L["Total missing payments above tolerance:"] <span style="color:red; font-weight:bold;">@($"{totalDifference:0.00}")</span></h4>
+                                </p>
+                        </div>
+                }
 
-	</Authorized>
-	<NotAuthorized>
-		<p>You're not loggged in.</p>
-	</NotAuthorized>
+        </Authorized>
+        <NotAuthorized>
+                <p>@L["You're not logged in."]</p>
+        </NotAuthorized>
 </AuthorizeView>
 
 @code {
@@ -245,7 +246,7 @@
 
 	private async Task SendEmail(Thrower thrower)
 	{
-		var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send registration email to this thrower?");
+                var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to send registration email to this thrower?"]);
 		if (confirmed)
 		{
 			await ThrowerService.ResendEmailAsync(thrower);
@@ -254,7 +255,7 @@
 
         private async Task SendUnpaidEmail(Thrower thrower)
         {
-            var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send registration email to this thrower?");
+            var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to send unpaid email to this thrower?"]);
             if (confirmed)
             {
                 await ThrowerService.SendUnpaidEmail(thrower);
@@ -266,19 +267,19 @@
 		var unpaidThrowers = throwers.Where(t => !t.PaymentDone).ToList();
 		if (unpaidThrowers.Any())
 		{
-			var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send emails to {unpaidThrowers.Count} unpaid throwers?");
+                        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to send emails to {0} unpaid throwers?", unpaidThrowers.Count]);
 			if (confirmed)
 			{
                                 foreach (var thrower in unpaidThrowers)
                                 {
                                         await ThrowerService.SendUnpaidEmail(thrower);
                                 }
-				await JSRuntime.InvokeVoidAsync("alert", "Emails sent to unpaid throwers.");
+                                await JSRuntime.InvokeVoidAsync("alert", L["Emails sent to unpaid throwers."]);
 			}
 		}
 		else
 		{
-			await JSRuntime.InvokeVoidAsync("alert", "No unpaid throwers to send emails to.");
+                        await JSRuntime.InvokeVoidAsync("alert", L["No unpaid throwers to send emails to."]);
 		}
 	}
 
@@ -287,25 +288,25 @@
                 var allThrowers = throwers.ToList();
                 if (allThrowers.Any())
                 {
-                        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to send emails to {allThrowers.Count} throwers?");
+                        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to send emails to {0} throwers?", allThrowers.Count]);
                         if (confirmed)
                         {
                                 foreach (var thrower in allThrowers)
                                 {
                                         ThrowerService.SendGeneralEmail(thrower, localMessage, englishMessage);
                                 }
-                                await JSRuntime.InvokeVoidAsync("alert", "Emails sent to throwers.");
+                                await JSRuntime.InvokeVoidAsync("alert", L["Emails sent to throwers."]);
                         }
                 }
                 else
                 {
-                        await JSRuntime.InvokeVoidAsync("alert", "No throwers to send emails to.");
+                        await JSRuntime.InvokeVoidAsync("alert", L["No throwers to send emails to."]);
                 }
         }
 
 	private async Task DeleteThrower(int id)
 	{
-		var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete this thrower?");
+                var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to delete this thrower?"]);
 		if (confirmed)
 		{
 			await ThrowerService.DeleteThrowerAsync(id);

--- a/CompetitionResults/Components/Shared/GeneralEmailModal.razor
+++ b/CompetitionResults/Components/Shared/GeneralEmailModal.razor
@@ -1,24 +1,26 @@
 @using Microsoft.AspNetCore.Components
+@inject IStringLocalizer<SharedResource> L
+
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">Send Email</h5>
+                <h5 class="modal-title">@L["Send Email"]</h5>
                 <button type="button" class="btn-close" @onclick="Close"></button>
             </div>
             <div class="modal-body">
                 <div class="mb-3">
-                    <label>Local message:</label>
+                    <label>@L["Local message:"]</label>
                     <InputTextArea class="form-control" @bind-Value="content.LocalMessage" />
                 </div>
                 <div class="mb-3">
-                    <label>English message:</label>
+                    <label>@L["English message:"]</label>
                     <InputTextArea class="form-control" @bind-Value="content.EnglishMessage" />
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" @onclick="Close">Cancel</button>
-                <button type="button" class="btn btn-primary" @onclick="Send">Send</button>
+                <button type="button" class="btn btn-secondary" @onclick="Close">@L["Cancel"]</button>
+                <button type="button" class="btn btn-primary" @onclick="Send">@L["Send"]</button>
             </div>
         </div>
     </div>

--- a/CompetitionResults/Components/Shared/ThrowerEditModal.razor
+++ b/CompetitionResults/Components/Shared/ThrowerEditModal.razor
@@ -4,6 +4,7 @@
 @inject CompetitionService CompetitionService
 @inject CategoryService CategoryService
 @inject CompetitionStateService CompetitionState
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
 	<div class="modal-dialog modal-lg">
@@ -12,29 +13,29 @@
 				<DataAnnotationsValidator />
 				<ValidationSummary />
 				<div class="modal-header">
-					<h5 class="modal-title">Edit Thrower</h5>
+                                        <h5 class="modal-title">@L["Edit Thrower"]</h5>
 					<button type="button" class="btn-close" @onclick="Close"></button>
 				</div>
 				<div class="modal-body">
 
 					<div class="form-grid">
 						<div>
-							<label for="name">Name:</label>
+                                                        <label for="name">@L["Name:"]</label>
 							<InputText id="name" @bind-Value="@_thrower.Name" />
 						</div>
 
 						<div>
-							<label for="surname">Surname:</label>
+                                                        <label for="surname">@L["Surname:"]</label>
 							<InputText id="surname" @bind-Value="@_thrower.Surname" />
 						</div>
 
 						<div>
-							<label for="nickname">Nickname:</label>
+                                                        <label for="nickname">@L["Nickname:"]</label>
 							<InputText id="nickname" @bind-Value="@_thrower.Nickname" />
 						</div>
 
 						<div>
-							<label for="nationality">Nationality:</label>
+                                                        <label for="nationality">@L["Nationality:"]</label>
 							<select id="nationality" @bind="_thrower.Nationality">
 								@foreach (var country in countries)
 								{
@@ -44,22 +45,22 @@
 						</div>
 
 						<div>
-							<label for="clubName">Club Name:</label>
+                                                        <label for="clubName">@L["Club Name:"]</label>
 							<InputText id="clubName" @bind-Value="@_thrower.ClubName" />
 						</div>
 
 						<div>
-							<label for="email">Email:</label>
+                                                        <label for="email">@L["Email:"]</label>
 							<InputText id="email" @bind-Value="@_thrower.Email" type="email" />
 						</div>
 
 						<div>
-							<label for="note">Note:</label>
+                                                        <label for="note">@L["Note:"]</label>
 							<InputTextArea id="note" @bind-Value="@_thrower.Note" />
 						</div>
 
 						<div>
-							<label for="categoryId">Category:</label>
+                                                        <label for="categoryId">@L["Category:"]</label>
 							<select id="categoryId" @bind="_thrower.CategoryId">
 								@foreach (var category in categories)
 								{
@@ -71,7 +72,7 @@
 						@if (_competition.CampingOnSiteAvailable)
 						{
 							<div>
-								<label for="isCampingOnSite">Camping on site:</label>
+                                                                <label for="isCampingOnSite">@L["Camping on site:"]</label>
 								<InputCheckbox id="isCampingOnSite" @bind-Value="_thrower.IsCampingOnSite" />
 							</div>
 						}
@@ -79,7 +80,7 @@
 						@if (_competition.TShirtAvailable)
 						{
 							<div>
-								<label for="wantTShirt">Interested in T-Shirt of competition for additional 10€:</label>
+                                                                <label for="wantTShirt">@L["Interested in T-Shirt of competition for additional 10€:"]</label>
 								<InputCheckbox id="wantTShirt" @bind-Value="_thrower.WantTShirt" />
 							</div>
 
@@ -87,8 +88,8 @@
 							{
 								<div>
 									<a href="@_competition.TShirtLink" target="_blank">
-										<img src="@_competition.TShirtLink" alt="T-Shirt design" style="width:30px;" />
-										<span>T-Shirt design</span>
+                                                                                <img src="@_competition.TShirtLink" alt="@L["T-Shirt design"]" style="width:30px;" />
+                                                                                <span>@L["T-Shirt design"]</span>
 									</a>
 								</div>
 							}
@@ -96,7 +97,7 @@
 							@if (_thrower.WantTShirt)
 							{
 								<div>
-									<label for="tShirtSize">Select T-Shirt Size:</label>
+                                                                        <label for="tShirtSize">@L["Select T-Shirt Size:"]</label>
 									<InputSelect id="tShirtSize" @bind-Value="_thrower.TShirtSize">
 										<option value="XS">XS</option>
 										<option value="S">S</option>
@@ -113,25 +114,25 @@
 						}
 
 						<div>
-							<label for="isPaid">Is Paid:</label>
+                                                        <label for="isPaid">@L["Is Paid:"]</label>
 							<InputCheckbox id="isPaid" @bind-Value="_thrower.PaymentDone" />
 						</div>
 
 						<div>
-							<label for="payment">Payment:</label>
+                                                        <label for="payment">@L["Payment:"]</label>
 							<input type="number" id="payment" @bind="_thrower.Payment" />
 						</div>
 
 						<div>
-							<label for="donotsend">Do not send registration email:</label>
+                                                        <label for="donotsend">@L["Do not send registration email:"]</label>
 							<InputCheckbox id="donotsend" @bind-Value="_thrower.DoNotSendRegistrationEmail" />
 						</div>
 
 					</div>
 				</div>
 				<div class="modal-footer">
-					<button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-					<button type="submit" class="btn btn-primary">Save changes</button>
+                                        <button type="button" class="btn btn-secondary" @onclick="Close">@L["Close"]</button>
+                                        <button type="submit" class="btn btn-primary">@L["Save changes"]</button>
 				</div>
 			</EditForm>
 		</div>

--- a/CompetitionResults/Resources/SharedResource.cs.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.resx
@@ -201,4 +201,211 @@
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
     <value>Opravdu chcete smazat tuto soutěž?</value>
   </data>
+  <data name="Add New Category" xml:space="preserve">
+    <value>Přidat novou kategorii</value>
+  </data>
+  <data name="Are you sure you want to delete this category?" xml:space="preserve">
+    <value>Opravdu chcete smazat tuto kategorii?</value>
+  </data>
+  <data name="Categories List" xml:space="preserve">
+    <value>Seznam kategorií</value>
+  </data>
+  <data name="Disciplines List" xml:space="preserve">
+    <value>Seznam disciplín</value>
+  </data>
+  <data name="Add New Discipline" xml:space="preserve">
+    <value>Přidat novou disciplínu</value>
+  </data>
+  <data name="Is Divided To Categories" xml:space="preserve">
+    <value>Je rozdělená do kategorií</value>
+  </data>
+  <data name="Has Positions Instead of Points" xml:space="preserve">
+    <value>Má pořadí místo bodů</value>
+  </data>
+  <data name="Has Decimal Points" xml:space="preserve">
+    <value>Má desetinné body</value>
+  </data>
+  <data name="Competition Manager Assignments" xml:space="preserve">
+    <value>Přiřazení manažerů soutěží</value>
+  </data>
+  <data name="Select manager:" xml:space="preserve">
+    <value>Vyberte manažera:</value>
+  </data>
+  <data name="-- Select Manager --" xml:space="preserve">
+    <value>-- Vyberte manažera --</value>
+  </data>
+  <data name="Competition" xml:space="preserve">
+    <value>Soutěž</value>
+  </data>
+  <data name="Assigned" xml:space="preserve">
+    <value>Přiřazeno</value>
+  </data>
+  <data name="Throwers List" xml:space="preserve">
+    <value>Seznam vrhačů</value>
+  </data>
+  <data name="Add New Thrower" xml:space="preserve">
+    <value>Přidat nového vrhače</value>
+  </data>
+  <data name="Send Emails to Unpaid Throwers" xml:space="preserve">
+    <value>Odeslat e-maily nezaplaceným vrhačům</value>
+  </data>
+  <data name="Send Emails" xml:space="preserve">
+    <value>Odeslat e-maily</value>
+  </data>
+  <data name="Surname" xml:space="preserve">
+    <value>Příjmení</value>
+  </data>
+  <data name="Nickname" xml:space="preserve">
+    <value>Přezdívka</value>
+  </data>
+  <data name="Nationality" xml:space="preserve">
+    <value>Národnost</value>
+  </data>
+  <data name="Flag" xml:space="preserve">
+    <value>Vlajka</value>
+  </data>
+  <data name="Club Name" xml:space="preserve">
+    <value>Název klubu</value>
+  </data>
+  <data name="Camping on site" xml:space="preserve">
+    <value>Kempování na místě</value>
+  </data>
+  <data name="Want T-Shirt (size)" xml:space="preserve">
+    <value>Chce tričko (velikost)</value>
+  </data>
+  <data name="Is paid (amount)" xml:space="preserve">
+    <value>Zaplaceno (částka)</value>
+  </data>
+  <data name="To Be Paid" xml:space="preserve">
+    <value>Doplatek</value>
+  </data>
+  <data name="Note" xml:space="preserve">
+    <value>Poznámka</value>
+  </data>
+  <data name="Send registration email" xml:space="preserve">
+    <value>Odeslat registrační e-mail</value>
+  </data>
+  <data name="Send unpaid email" xml:space="preserve">
+    <value>Odeslat e-mail o nezaplacení</value>
+  </data>
+  <data name="Total throwers: {0}" xml:space="preserve">
+    <value>Celkem vrhačů: {0}</value>
+  </data>
+  <data name="Total payments: {0}" xml:space="preserve">
+    <value>Celkem plateb: {0}</value>
+  </data>
+  <data name="Total countries: {0}" xml:space="preserve">
+    <value>Celkem zemí: {0}</value>
+  </data>
+  <data name="Categories:" xml:space="preserve">
+    <value>Kategorie:</value>
+  </data>
+  <data name="Total campers: {0}" xml:space="preserve">
+    <value>Celkem kempujících: {0}</value>
+  </data>
+  <data name="T-shirts:" xml:space="preserve">
+    <value>Trička:</value>
+  </data>
+  <data name="Throwers by country:" xml:space="preserve">
+    <value>Vrhači podle zemí:</value>
+  </data>
+  <data name="Total missing payments above tolerance:" xml:space="preserve">
+    <value>Celkový chybějící doplatek nad toleranci:</value>
+  </data>
+  <data name="Are you sure you want to send registration email to this thrower?" xml:space="preserve">
+    <value>Opravdu chcete odeslat registrační e-mail tomuto vrhači?</value>
+  </data>
+  <data name="Are you sure you want to send unpaid email to this thrower?" xml:space="preserve">
+    <value>Opravdu chcete odeslat e-mail o nezaplacení tomuto vrhači?</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} unpaid throwers?" xml:space="preserve">
+    <value>Opravdu chcete odeslat e-maily {0} nezaplaceným vrhačům?</value>
+  </data>
+  <data name="Emails sent to unpaid throwers." xml:space="preserve">
+    <value>E-maily byly odeslány nezaplaceným vrhačům.</value>
+  </data>
+  <data name="No unpaid throwers to send emails to." xml:space="preserve">
+    <value>Žádní nezaplacení vrhači pro odeslání e-mailů.</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} throwers?" xml:space="preserve">
+    <value>Opravdu chcete odeslat e-maily {0} vrhačům?</value>
+  </data>
+  <data name="Emails sent to throwers." xml:space="preserve">
+    <value>E-maily byly odeslány vrhačům.</value>
+  </data>
+  <data name="No throwers to send emails to." xml:space="preserve">
+    <value>Žádní vrhači pro odeslání e-mailů.</value>
+  </data>
+  <data name="Are you sure you want to delete this thrower?" xml:space="preserve">
+    <value>Opravdu chcete smazat tohoto vrhače?</value>
+  </data>
+  <data name="Send Email" xml:space="preserve">
+    <value>Odeslat e-mail</value>
+  </data>
+  <data name="Local message:" xml:space="preserve">
+    <value>Zpráva v místním jazyce:</value>
+  </data>
+  <data name="English message:" xml:space="preserve">
+    <value>Zpráva v angličtině:</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Zrušit</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Odeslat</value>
+  </data>
+  <data name="Edit Thrower" xml:space="preserve">
+    <value>Upravit vrhače</value>
+  </data>
+  <data name="Name:" xml:space="preserve">
+    <value>Jméno:</value>
+  </data>
+  <data name="Surname:" xml:space="preserve">
+    <value>Příjmení:</value>
+  </data>
+  <data name="Nickname:" xml:space="preserve">
+    <value>Přezdívka:</value>
+  </data>
+  <data name="Nationality:" xml:space="preserve">
+    <value>Národnost:</value>
+  </data>
+  <data name="Club Name:" xml:space="preserve">
+    <value>Název klubu:</value>
+  </data>
+  <data name="Email:" xml:space="preserve">
+    <value>E-mail:</value>
+  </data>
+  <data name="Note:" xml:space="preserve">
+    <value>Poznámka:</value>
+  </data>
+  <data name="Category:" xml:space="preserve">
+    <value>Kategorie:</value>
+  </data>
+  <data name="Camping on site:" xml:space="preserve">
+    <value>Kempování na místě:</value>
+  </data>
+  <data name="Interested in T-Shirt of competition for additional 10€:" xml:space="preserve">
+    <value>Má zájem o tričko ze soutěže za příplatek 10 €:</value>
+  </data>
+  <data name="T-Shirt design" xml:space="preserve">
+    <value>Náhled trička</value>
+  </data>
+  <data name="Select T-Shirt Size:" xml:space="preserve">
+    <value>Vyberte velikost trička:</value>
+  </data>
+  <data name="Is Paid:" xml:space="preserve">
+    <value>Zaplaceno:</value>
+  </data>
+  <data name="Payment:" xml:space="preserve">
+    <value>Platba:</value>
+  </data>
+  <data name="Do not send registration email:" xml:space="preserve">
+    <value>Nezasílat registrační e-mail:</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Zavřít</value>
+  </data>
+  <data name="Save changes" xml:space="preserve">
+    <value>Uložit změny</value>
+  </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.fr.resx
+++ b/CompetitionResults/Resources/SharedResource.fr.resx
@@ -201,4 +201,211 @@
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
     <value>Êtes-vous sûr de vouloir supprimer cette compétition ?</value>
   </data>
+  <data name="Add New Category" xml:space="preserve">
+    <value>Ajouter une nouvelle catégorie</value>
+  </data>
+  <data name="Are you sure you want to delete this category?" xml:space="preserve">
+    <value>Voulez-vous vraiment supprimer cette catégorie ?</value>
+  </data>
+  <data name="Categories List" xml:space="preserve">
+    <value>Liste des catégories</value>
+  </data>
+  <data name="Disciplines List" xml:space="preserve">
+    <value>Liste des disciplines</value>
+  </data>
+  <data name="Add New Discipline" xml:space="preserve">
+    <value>Ajouter une nouvelle discipline</value>
+  </data>
+  <data name="Is Divided To Categories" xml:space="preserve">
+    <value>Est divisée en catégories</value>
+  </data>
+  <data name="Has Positions Instead of Points" xml:space="preserve">
+    <value>Utilise des positions plutôt que des points</value>
+  </data>
+  <data name="Has Decimal Points" xml:space="preserve">
+    <value>Utilise des points décimaux</value>
+  </data>
+  <data name="Competition Manager Assignments" xml:space="preserve">
+    <value>Affectations des gestionnaires de compétition</value>
+  </data>
+  <data name="Select manager:" xml:space="preserve">
+    <value>Sélectionnez un gestionnaire :</value>
+  </data>
+  <data name="-- Select Manager --" xml:space="preserve">
+    <value>-- Sélectionnez un gestionnaire --</value>
+  </data>
+  <data name="Competition" xml:space="preserve">
+    <value>Compétition</value>
+  </data>
+  <data name="Assigned" xml:space="preserve">
+    <value>Affecté</value>
+  </data>
+  <data name="Throwers List" xml:space="preserve">
+    <value>Liste des lanceurs</value>
+  </data>
+  <data name="Add New Thrower" xml:space="preserve">
+    <value>Ajouter un nouveau lanceur</value>
+  </data>
+  <data name="Send Emails to Unpaid Throwers" xml:space="preserve">
+    <value>Envoyer des e-mails aux lanceurs non payés</value>
+  </data>
+  <data name="Send Emails" xml:space="preserve">
+    <value>Envoyer des e-mails</value>
+  </data>
+  <data name="Surname" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="Nickname" xml:space="preserve">
+    <value>Surnom</value>
+  </data>
+  <data name="Nationality" xml:space="preserve">
+    <value>Nationalité</value>
+  </data>
+  <data name="Flag" xml:space="preserve">
+    <value>Drapeau</value>
+  </data>
+  <data name="Club Name" xml:space="preserve">
+    <value>Nom du club</value>
+  </data>
+  <data name="Camping on site" xml:space="preserve">
+    <value>Camping sur place</value>
+  </data>
+  <data name="Want T-Shirt (size)" xml:space="preserve">
+    <value>Souhaite un t-shirt (taille)</value>
+  </data>
+  <data name="Is paid (amount)" xml:space="preserve">
+    <value>Payé (montant)</value>
+  </data>
+  <data name="To Be Paid" xml:space="preserve">
+    <value>À payer</value>
+  </data>
+  <data name="Note" xml:space="preserve">
+    <value>Note</value>
+  </data>
+  <data name="Send registration email" xml:space="preserve">
+    <value>Envoyer l'e-mail d'inscription</value>
+  </data>
+  <data name="Send unpaid email" xml:space="preserve">
+    <value>Envoyer l'e-mail de relance</value>
+  </data>
+  <data name="Total throwers: {0}" xml:space="preserve">
+    <value>Total des lanceurs : {0}</value>
+  </data>
+  <data name="Total payments: {0}" xml:space="preserve">
+    <value>Total des paiements : {0}</value>
+  </data>
+  <data name="Total countries: {0}" xml:space="preserve">
+    <value>Nombre total de pays : {0}</value>
+  </data>
+  <data name="Categories:" xml:space="preserve">
+    <value>Catégories :</value>
+  </data>
+  <data name="Total campers: {0}" xml:space="preserve">
+    <value>Total des campeurs : {0}</value>
+  </data>
+  <data name="T-shirts:" xml:space="preserve">
+    <value>T-shirts :</value>
+  </data>
+  <data name="Throwers by country:" xml:space="preserve">
+    <value>Lanceurs par pays :</value>
+  </data>
+  <data name="Total missing payments above tolerance:" xml:space="preserve">
+    <value>Total des paiements manquants au-delà de la tolérance :</value>
+  </data>
+  <data name="Are you sure you want to send registration email to this thrower?" xml:space="preserve">
+    <value>Voulez-vous vraiment envoyer l'e-mail d'inscription à ce lanceur ?</value>
+  </data>
+  <data name="Are you sure you want to send unpaid email to this thrower?" xml:space="preserve">
+    <value>Voulez-vous vraiment envoyer l'e-mail de relance à ce lanceur ?</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} unpaid throwers?" xml:space="preserve">
+    <value>Voulez-vous vraiment envoyer des e-mails à {0} lanceurs non payés ?</value>
+  </data>
+  <data name="Emails sent to unpaid throwers." xml:space="preserve">
+    <value>E-mails envoyés aux lanceurs non payés.</value>
+  </data>
+  <data name="No unpaid throwers to send emails to." xml:space="preserve">
+    <value>Aucun lanceur non payé à qui envoyer d'e-mails.</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} throwers?" xml:space="preserve">
+    <value>Voulez-vous vraiment envoyer des e-mails à {0} lanceurs ?</value>
+  </data>
+  <data name="Emails sent to throwers." xml:space="preserve">
+    <value>E-mails envoyés aux lanceurs.</value>
+  </data>
+  <data name="No throwers to send emails to." xml:space="preserve">
+    <value>Aucun lanceur à qui envoyer d'e-mails.</value>
+  </data>
+  <data name="Are you sure you want to delete this thrower?" xml:space="preserve">
+    <value>Voulez-vous vraiment supprimer ce lanceur ?</value>
+  </data>
+  <data name="Send Email" xml:space="preserve">
+    <value>Envoyer un e-mail</value>
+  </data>
+  <data name="Local message:" xml:space="preserve">
+    <value>Message local :</value>
+  </data>
+  <data name="English message:" xml:space="preserve">
+    <value>Message en anglais :</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Envoyer</value>
+  </data>
+  <data name="Edit Thrower" xml:space="preserve">
+    <value>Modifier le lanceur</value>
+  </data>
+  <data name="Name:" xml:space="preserve">
+    <value>Prénom :</value>
+  </data>
+  <data name="Surname:" xml:space="preserve">
+    <value>Nom :</value>
+  </data>
+  <data name="Nickname:" xml:space="preserve">
+    <value>Surnom :</value>
+  </data>
+  <data name="Nationality:" xml:space="preserve">
+    <value>Nationalité :</value>
+  </data>
+  <data name="Club Name:" xml:space="preserve">
+    <value>Nom du club :</value>
+  </data>
+  <data name="Email:" xml:space="preserve">
+    <value>E-mail :</value>
+  </data>
+  <data name="Note:" xml:space="preserve">
+    <value>Note :</value>
+  </data>
+  <data name="Category:" xml:space="preserve">
+    <value>Catégorie :</value>
+  </data>
+  <data name="Camping on site:" xml:space="preserve">
+    <value>Camping sur place :</value>
+  </data>
+  <data name="Interested in T-Shirt of competition for additional 10€:" xml:space="preserve">
+    <value>Intéressé par le t-shirt de la compétition pour 10€ supplémentaires :</value>
+  </data>
+  <data name="T-Shirt design" xml:space="preserve">
+    <value>Design du t-shirt</value>
+  </data>
+  <data name="Select T-Shirt Size:" xml:space="preserve">
+    <value>Choisissez la taille du t-shirt :</value>
+  </data>
+  <data name="Is Paid:" xml:space="preserve">
+    <value>Payé :</value>
+  </data>
+  <data name="Payment:" xml:space="preserve">
+    <value>Paiement :</value>
+  </data>
+  <data name="Do not send registration email:" xml:space="preserve">
+    <value>Ne pas envoyer l'e-mail d'inscription :</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="Save changes" xml:space="preserve">
+    <value>Enregistrer les modifications</value>
+  </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.it.resx
+++ b/CompetitionResults/Resources/SharedResource.it.resx
@@ -201,4 +201,211 @@
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
     <value>Sei sicuro di voler eliminare questa competizione?</value>
   </data>
+  <data name="Add New Category" xml:space="preserve">
+    <value>Aggiungi nuova categoria</value>
+  </data>
+  <data name="Are you sure you want to delete this category?" xml:space="preserve">
+    <value>Sei sicuro di voler eliminare questa categoria?</value>
+  </data>
+  <data name="Categories List" xml:space="preserve">
+    <value>Elenco categorie</value>
+  </data>
+  <data name="Disciplines List" xml:space="preserve">
+    <value>Elenco discipline</value>
+  </data>
+  <data name="Add New Discipline" xml:space="preserve">
+    <value>Aggiungi nuova disciplina</value>
+  </data>
+  <data name="Is Divided To Categories" xml:space="preserve">
+    <value>È suddivisa in categorie</value>
+  </data>
+  <data name="Has Positions Instead of Points" xml:space="preserve">
+    <value>Ha posizioni invece di punti</value>
+  </data>
+  <data name="Has Decimal Points" xml:space="preserve">
+    <value>Ha punti decimali</value>
+  </data>
+  <data name="Competition Manager Assignments" xml:space="preserve">
+    <value>Assegnazioni dei responsabili gara</value>
+  </data>
+  <data name="Select manager:" xml:space="preserve">
+    <value>Seleziona responsabile:</value>
+  </data>
+  <data name="-- Select Manager --" xml:space="preserve">
+    <value>-- Seleziona responsabile --</value>
+  </data>
+  <data name="Competition" xml:space="preserve">
+    <value>Gara</value>
+  </data>
+  <data name="Assigned" xml:space="preserve">
+    <value>Assegnato</value>
+  </data>
+  <data name="Throwers List" xml:space="preserve">
+    <value>Elenco lanciatori</value>
+  </data>
+  <data name="Add New Thrower" xml:space="preserve">
+    <value>Aggiungi nuovo lanciatore</value>
+  </data>
+  <data name="Send Emails to Unpaid Throwers" xml:space="preserve">
+    <value>Invia e-mail ai lanciatori non paganti</value>
+  </data>
+  <data name="Send Emails" xml:space="preserve">
+    <value>Invia e-mail</value>
+  </data>
+  <data name="Surname" xml:space="preserve">
+    <value>Cognome</value>
+  </data>
+  <data name="Nickname" xml:space="preserve">
+    <value>Soprannome</value>
+  </data>
+  <data name="Nationality" xml:space="preserve">
+    <value>Nazionalità</value>
+  </data>
+  <data name="Flag" xml:space="preserve">
+    <value>Bandiera</value>
+  </data>
+  <data name="Club Name" xml:space="preserve">
+    <value>Nome del club</value>
+  </data>
+  <data name="Camping on site" xml:space="preserve">
+    <value>Campeggio sul posto</value>
+  </data>
+  <data name="Want T-Shirt (size)" xml:space="preserve">
+    <value>Desidera la maglietta (taglia)</value>
+  </data>
+  <data name="Is paid (amount)" xml:space="preserve">
+    <value>Pagato (importo)</value>
+  </data>
+  <data name="To Be Paid" xml:space="preserve">
+    <value>Da pagare</value>
+  </data>
+  <data name="Note" xml:space="preserve">
+    <value>Nota</value>
+  </data>
+  <data name="Send registration email" xml:space="preserve">
+    <value>Invia e-mail di registrazione</value>
+  </data>
+  <data name="Send unpaid email" xml:space="preserve">
+    <value>Invia e-mail di sollecito</value>
+  </data>
+  <data name="Total throwers: {0}" xml:space="preserve">
+    <value>Totale lanciatori: {0}</value>
+  </data>
+  <data name="Total payments: {0}" xml:space="preserve">
+    <value>Totale pagamenti: {0}</value>
+  </data>
+  <data name="Total countries: {0}" xml:space="preserve">
+    <value>Totale paesi: {0}</value>
+  </data>
+  <data name="Categories:" xml:space="preserve">
+    <value>Categorie:</value>
+  </data>
+  <data name="Total campers: {0}" xml:space="preserve">
+    <value>Totale campeggiatori: {0}</value>
+  </data>
+  <data name="T-shirts:" xml:space="preserve">
+    <value>Magliette:</value>
+  </data>
+  <data name="Throwers by country:" xml:space="preserve">
+    <value>Lanciatori per paese:</value>
+  </data>
+  <data name="Total missing payments above tolerance:" xml:space="preserve">
+    <value>Pagamenti mancanti oltre la tolleranza totali:</value>
+  </data>
+  <data name="Are you sure you want to send registration email to this thrower?" xml:space="preserve">
+    <value>Sei sicuro di voler inviare l'e-mail di registrazione a questo lanciatore?</value>
+  </data>
+  <data name="Are you sure you want to send unpaid email to this thrower?" xml:space="preserve">
+    <value>Sei sicuro di voler inviare l'e-mail di sollecito a questo lanciatore?</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} unpaid throwers?" xml:space="preserve">
+    <value>Sei sicuro di voler inviare e-mail a {0} lanciatori non paganti?</value>
+  </data>
+  <data name="Emails sent to unpaid throwers." xml:space="preserve">
+    <value>E-mail inviate ai lanciatori non paganti.</value>
+  </data>
+  <data name="No unpaid throwers to send emails to." xml:space="preserve">
+    <value>Nessun lanciatore non pagante a cui inviare e-mail.</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} throwers?" xml:space="preserve">
+    <value>Sei sicuro di voler inviare e-mail a {0} lanciatori?</value>
+  </data>
+  <data name="Emails sent to throwers." xml:space="preserve">
+    <value>E-mail inviate ai lanciatori.</value>
+  </data>
+  <data name="No throwers to send emails to." xml:space="preserve">
+    <value>Nessun lanciatore a cui inviare e-mail.</value>
+  </data>
+  <data name="Are you sure you want to delete this thrower?" xml:space="preserve">
+    <value>Sei sicuro di voler eliminare questo lanciatore?</value>
+  </data>
+  <data name="Send Email" xml:space="preserve">
+    <value>Invia e-mail</value>
+  </data>
+  <data name="Local message:" xml:space="preserve">
+    <value>Messaggio locale:</value>
+  </data>
+  <data name="English message:" xml:space="preserve">
+    <value>Messaggio in inglese:</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annulla</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Invia</value>
+  </data>
+  <data name="Edit Thrower" xml:space="preserve">
+    <value>Modifica lanciatore</value>
+  </data>
+  <data name="Name:" xml:space="preserve">
+    <value>Nome:</value>
+  </data>
+  <data name="Surname:" xml:space="preserve">
+    <value>Cognome:</value>
+  </data>
+  <data name="Nickname:" xml:space="preserve">
+    <value>Soprannome:</value>
+  </data>
+  <data name="Nationality:" xml:space="preserve">
+    <value>Nazionalità:</value>
+  </data>
+  <data name="Club Name:" xml:space="preserve">
+    <value>Nome del club:</value>
+  </data>
+  <data name="Email:" xml:space="preserve">
+    <value>E-mail:</value>
+  </data>
+  <data name="Note:" xml:space="preserve">
+    <value>Nota:</value>
+  </data>
+  <data name="Category:" xml:space="preserve">
+    <value>Categoria:</value>
+  </data>
+  <data name="Camping on site:" xml:space="preserve">
+    <value>Campeggio sul posto:</value>
+  </data>
+  <data name="Interested in T-Shirt of competition for additional 10€:" xml:space="preserve">
+    <value>Interessato alla maglietta della competizione con un supplemento di 10€:</value>
+  </data>
+  <data name="T-Shirt design" xml:space="preserve">
+    <value>Design della maglietta</value>
+  </data>
+  <data name="Select T-Shirt Size:" xml:space="preserve">
+    <value>Seleziona la taglia della maglietta:</value>
+  </data>
+  <data name="Is Paid:" xml:space="preserve">
+    <value>Pagato:</value>
+  </data>
+  <data name="Payment:" xml:space="preserve">
+    <value>Pagamento:</value>
+  </data>
+  <data name="Do not send registration email:" xml:space="preserve">
+    <value>Non inviare l'e-mail di registrazione:</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Chiudi</value>
+  </data>
+  <data name="Save changes" xml:space="preserve">
+    <value>Salva modifiche</value>
+  </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.ru.resx
+++ b/CompetitionResults/Resources/SharedResource.ru.resx
@@ -201,4 +201,211 @@
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
     <value>Вы уверены, что хотите удалить это соревнование?</value>
   </data>
+  <data name="Add New Category" xml:space="preserve">
+    <value>Добавить новую категорию</value>
+  </data>
+  <data name="Are you sure you want to delete this category?" xml:space="preserve">
+    <value>Вы уверены, что хотите удалить эту категорию?</value>
+  </data>
+  <data name="Categories List" xml:space="preserve">
+    <value>Список категорий</value>
+  </data>
+  <data name="Disciplines List" xml:space="preserve">
+    <value>Список дисциплин</value>
+  </data>
+  <data name="Add New Discipline" xml:space="preserve">
+    <value>Добавить новую дисциплину</value>
+  </data>
+  <data name="Is Divided To Categories" xml:space="preserve">
+    <value>Разделена на категории</value>
+  </data>
+  <data name="Has Positions Instead of Points" xml:space="preserve">
+    <value>Использует места вместо очков</value>
+  </data>
+  <data name="Has Decimal Points" xml:space="preserve">
+    <value>Использует десятичные очки</value>
+  </data>
+  <data name="Competition Manager Assignments" xml:space="preserve">
+    <value>Назначения менеджеров соревнований</value>
+  </data>
+  <data name="Select manager:" xml:space="preserve">
+    <value>Выберите менеджера:</value>
+  </data>
+  <data name="-- Select Manager --" xml:space="preserve">
+    <value>-- Выберите менеджера --</value>
+  </data>
+  <data name="Competition" xml:space="preserve">
+    <value>Соревнование</value>
+  </data>
+  <data name="Assigned" xml:space="preserve">
+    <value>Назначено</value>
+  </data>
+  <data name="Throwers List" xml:space="preserve">
+    <value>Список метателей</value>
+  </data>
+  <data name="Add New Thrower" xml:space="preserve">
+    <value>Добавить нового метателя</value>
+  </data>
+  <data name="Send Emails to Unpaid Throwers" xml:space="preserve">
+    <value>Отправить письма неоплатившим метателям</value>
+  </data>
+  <data name="Send Emails" xml:space="preserve">
+    <value>Отправить письма</value>
+  </data>
+  <data name="Surname" xml:space="preserve">
+    <value>Фамилия</value>
+  </data>
+  <data name="Nickname" xml:space="preserve">
+    <value>Никнейм</value>
+  </data>
+  <data name="Nationality" xml:space="preserve">
+    <value>Гражданство</value>
+  </data>
+  <data name="Flag" xml:space="preserve">
+    <value>Флаг</value>
+  </data>
+  <data name="Club Name" xml:space="preserve">
+    <value>Название клуба</value>
+  </data>
+  <data name="Camping on site" xml:space="preserve">
+    <value>Кемпинг на месте</value>
+  </data>
+  <data name="Want T-Shirt (size)" xml:space="preserve">
+    <value>Хочет футболку (размер)</value>
+  </data>
+  <data name="Is paid (amount)" xml:space="preserve">
+    <value>Оплачено (сумма)</value>
+  </data>
+  <data name="To Be Paid" xml:space="preserve">
+    <value>К оплате</value>
+  </data>
+  <data name="Note" xml:space="preserve">
+    <value>Примечание</value>
+  </data>
+  <data name="Send registration email" xml:space="preserve">
+    <value>Отправить регистрационное письмо</value>
+  </data>
+  <data name="Send unpaid email" xml:space="preserve">
+    <value>Отправить письмо о задолженности</value>
+  </data>
+  <data name="Total throwers: {0}" xml:space="preserve">
+    <value>Всего метателей: {0}</value>
+  </data>
+  <data name="Total payments: {0}" xml:space="preserve">
+    <value>Всего оплат: {0}</value>
+  </data>
+  <data name="Total countries: {0}" xml:space="preserve">
+    <value>Всего стран: {0}</value>
+  </data>
+  <data name="Categories:" xml:space="preserve">
+    <value>Категории:</value>
+  </data>
+  <data name="Total campers: {0}" xml:space="preserve">
+    <value>Всего кемперов: {0}</value>
+  </data>
+  <data name="T-shirts:" xml:space="preserve">
+    <value>Футболки:</value>
+  </data>
+  <data name="Throwers by country:" xml:space="preserve">
+    <value>Метатели по странам:</value>
+  </data>
+  <data name="Total missing payments above tolerance:" xml:space="preserve">
+    <value>Общая сумма недоплат сверх допуска:</value>
+  </data>
+  <data name="Are you sure you want to send registration email to this thrower?" xml:space="preserve">
+    <value>Вы уверены, что хотите отправить регистрационное письмо этому метателю?</value>
+  </data>
+  <data name="Are you sure you want to send unpaid email to this thrower?" xml:space="preserve">
+    <value>Вы уверены, что хотите отправить письмо о задолженности этому метателю?</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} unpaid throwers?" xml:space="preserve">
+    <value>Вы уверены, что хотите отправить письма {0} неоплатившим метателям?</value>
+  </data>
+  <data name="Emails sent to unpaid throwers." xml:space="preserve">
+    <value>Письма отправлены неоплатившим метателям.</value>
+  </data>
+  <data name="No unpaid throwers to send emails to." xml:space="preserve">
+    <value>Нет неоплативших метателей для отправки писем.</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} throwers?" xml:space="preserve">
+    <value>Вы уверены, что хотите отправить письма {0} метателям?</value>
+  </data>
+  <data name="Emails sent to throwers." xml:space="preserve">
+    <value>Письма отправлены метателям.</value>
+  </data>
+  <data name="No throwers to send emails to." xml:space="preserve">
+    <value>Нет метателей для отправки писем.</value>
+  </data>
+  <data name="Are you sure you want to delete this thrower?" xml:space="preserve">
+    <value>Вы уверены, что хотите удалить этого метателя?</value>
+  </data>
+  <data name="Send Email" xml:space="preserve">
+    <value>Отправить письмо</value>
+  </data>
+  <data name="Local message:" xml:space="preserve">
+    <value>Сообщение на местном языке:</value>
+  </data>
+  <data name="English message:" xml:space="preserve">
+    <value>Сообщение на английском:</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Отправить</value>
+  </data>
+  <data name="Edit Thrower" xml:space="preserve">
+    <value>Редактировать метателя</value>
+  </data>
+  <data name="Name:" xml:space="preserve">
+    <value>Имя:</value>
+  </data>
+  <data name="Surname:" xml:space="preserve">
+    <value>Фамилия:</value>
+  </data>
+  <data name="Nickname:" xml:space="preserve">
+    <value>Никнейм:</value>
+  </data>
+  <data name="Nationality:" xml:space="preserve">
+    <value>Гражданство:</value>
+  </data>
+  <data name="Club Name:" xml:space="preserve">
+    <value>Название клуба:</value>
+  </data>
+  <data name="Email:" xml:space="preserve">
+    <value>E-mail:</value>
+  </data>
+  <data name="Note:" xml:space="preserve">
+    <value>Примечание:</value>
+  </data>
+  <data name="Category:" xml:space="preserve">
+    <value>Категория:</value>
+  </data>
+  <data name="Camping on site:" xml:space="preserve">
+    <value>Кемпинг на месте:</value>
+  </data>
+  <data name="Interested in T-Shirt of competition for additional 10€:" xml:space="preserve">
+    <value>Интересуется футболкой соревнования за доплату 10 €:</value>
+  </data>
+  <data name="T-Shirt design" xml:space="preserve">
+    <value>Дизайн футболки</value>
+  </data>
+  <data name="Select T-Shirt Size:" xml:space="preserve">
+    <value>Выберите размер футболки:</value>
+  </data>
+  <data name="Is Paid:" xml:space="preserve">
+    <value>Оплачено:</value>
+  </data>
+  <data name="Payment:" xml:space="preserve">
+    <value>Платеж:</value>
+  </data>
+  <data name="Do not send registration email:" xml:space="preserve">
+    <value>Не отправлять регистрационное письмо:</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="Save changes" xml:space="preserve">
+    <value>Сохранить изменения</value>
+  </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.sk.resx
+++ b/CompetitionResults/Resources/SharedResource.sk.resx
@@ -201,4 +201,211 @@
   <data name="Are you sure you want to delete this competition?" xml:space="preserve">
     <value>Naozaj chcete vymazať túto súťaž?</value>
   </data>
+  <data name="Add New Category" xml:space="preserve">
+    <value>Pridať novú kategóriu</value>
+  </data>
+  <data name="Are you sure you want to delete this category?" xml:space="preserve">
+    <value>Naozaj chcete odstrániť túto kategóriu?</value>
+  </data>
+  <data name="Categories List" xml:space="preserve">
+    <value>Zoznam kategórií</value>
+  </data>
+  <data name="Disciplines List" xml:space="preserve">
+    <value>Zoznam disciplín</value>
+  </data>
+  <data name="Add New Discipline" xml:space="preserve">
+    <value>Pridať novú disciplínu</value>
+  </data>
+  <data name="Is Divided To Categories" xml:space="preserve">
+    <value>Je rozdelená do kategórií</value>
+  </data>
+  <data name="Has Positions Instead of Points" xml:space="preserve">
+    <value>Má poradie namiesto bodov</value>
+  </data>
+  <data name="Has Decimal Points" xml:space="preserve">
+    <value>Má desatinné body</value>
+  </data>
+  <data name="Competition Manager Assignments" xml:space="preserve">
+    <value>Priradenie manažérov súťaží</value>
+  </data>
+  <data name="Select manager:" xml:space="preserve">
+    <value>Vyberte manažéra:</value>
+  </data>
+  <data name="-- Select Manager --" xml:space="preserve">
+    <value>-- Vyberte manažéra --</value>
+  </data>
+  <data name="Competition" xml:space="preserve">
+    <value>Súťaž</value>
+  </data>
+  <data name="Assigned" xml:space="preserve">
+    <value>Priradené</value>
+  </data>
+  <data name="Throwers List" xml:space="preserve">
+    <value>Zoznam vrhačov</value>
+  </data>
+  <data name="Add New Thrower" xml:space="preserve">
+    <value>Pridať nového vrhača</value>
+  </data>
+  <data name="Send Emails to Unpaid Throwers" xml:space="preserve">
+    <value>Odoslať e-maily neplatiacim vrhačom</value>
+  </data>
+  <data name="Send Emails" xml:space="preserve">
+    <value>Odoslať e-maily</value>
+  </data>
+  <data name="Surname" xml:space="preserve">
+    <value>Priezvisko</value>
+  </data>
+  <data name="Nickname" xml:space="preserve">
+    <value>Prezývka</value>
+  </data>
+  <data name="Nationality" xml:space="preserve">
+    <value>Národnosť</value>
+  </data>
+  <data name="Flag" xml:space="preserve">
+    <value>Vlajka</value>
+  </data>
+  <data name="Club Name" xml:space="preserve">
+    <value>Názov klubu</value>
+  </data>
+  <data name="Camping on site" xml:space="preserve">
+    <value>Kempovanie na mieste</value>
+  </data>
+  <data name="Want T-Shirt (size)" xml:space="preserve">
+    <value>Chce tričko (veľkosť)</value>
+  </data>
+  <data name="Is paid (amount)" xml:space="preserve">
+    <value>Zaplatené (suma)</value>
+  </data>
+  <data name="To Be Paid" xml:space="preserve">
+    <value>Na zaplatenie</value>
+  </data>
+  <data name="Note" xml:space="preserve">
+    <value>Poznámka</value>
+  </data>
+  <data name="Send registration email" xml:space="preserve">
+    <value>Odoslať registračný e-mail</value>
+  </data>
+  <data name="Send unpaid email" xml:space="preserve">
+    <value>Odoslať e-mail o nezaplatení</value>
+  </data>
+  <data name="Total throwers: {0}" xml:space="preserve">
+    <value>Spolu vrhačov: {0}</value>
+  </data>
+  <data name="Total payments: {0}" xml:space="preserve">
+    <value>Spolu platieb: {0}</value>
+  </data>
+  <data name="Total countries: {0}" xml:space="preserve">
+    <value>Spolu krajín: {0}</value>
+  </data>
+  <data name="Categories:" xml:space="preserve">
+    <value>Kategórie:</value>
+  </data>
+  <data name="Total campers: {0}" xml:space="preserve">
+    <value>Spolu kempujúcich: {0}</value>
+  </data>
+  <data name="T-shirts:" xml:space="preserve">
+    <value>Tričká:</value>
+  </data>
+  <data name="Throwers by country:" xml:space="preserve">
+    <value>Vrhači podľa krajín:</value>
+  </data>
+  <data name="Total missing payments above tolerance:" xml:space="preserve">
+    <value>Celkový chýbajúci doplatok nad toleranciu:</value>
+  </data>
+  <data name="Are you sure you want to send registration email to this thrower?" xml:space="preserve">
+    <value>Naozaj chcete odoslať registračný e-mail tomuto vrhačovi?</value>
+  </data>
+  <data name="Are you sure you want to send unpaid email to this thrower?" xml:space="preserve">
+    <value>Naozaj chcete odoslať e-mail o nezaplatení tomuto vrhačovi?</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} unpaid throwers?" xml:space="preserve">
+    <value>Naozaj chcete odoslať e-maily {0} neplatiacim vrhačom?</value>
+  </data>
+  <data name="Emails sent to unpaid throwers." xml:space="preserve">
+    <value>E-maily odoslané neplatiacim vrhačom.</value>
+  </data>
+  <data name="No unpaid throwers to send emails to." xml:space="preserve">
+    <value>Žiadni neplatiaci vrhači na odoslanie e-mailov.</value>
+  </data>
+  <data name="Are you sure you want to send emails to {0} throwers?" xml:space="preserve">
+    <value>Naozaj chcete odoslať e-maily {0} vrhačom?</value>
+  </data>
+  <data name="Emails sent to throwers." xml:space="preserve">
+    <value>E-maily odoslané vrhačom.</value>
+  </data>
+  <data name="No throwers to send emails to." xml:space="preserve">
+    <value>Žiadni vrhači na odoslanie e-mailov.</value>
+  </data>
+  <data name="Are you sure you want to delete this thrower?" xml:space="preserve">
+    <value>Naozaj chcete odstrániť tohto vrhača?</value>
+  </data>
+  <data name="Send Email" xml:space="preserve">
+    <value>Odoslať e-mail</value>
+  </data>
+  <data name="Local message:" xml:space="preserve">
+    <value>Správa v miestnom jazyku:</value>
+  </data>
+  <data name="English message:" xml:space="preserve">
+    <value>Správa v angličtine:</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Zrušiť</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Odoslať</value>
+  </data>
+  <data name="Edit Thrower" xml:space="preserve">
+    <value>Upraviť vrhača</value>
+  </data>
+  <data name="Name:" xml:space="preserve">
+    <value>Meno:</value>
+  </data>
+  <data name="Surname:" xml:space="preserve">
+    <value>Priezvisko:</value>
+  </data>
+  <data name="Nickname:" xml:space="preserve">
+    <value>Prezývka:</value>
+  </data>
+  <data name="Nationality:" xml:space="preserve">
+    <value>Národnosť:</value>
+  </data>
+  <data name="Club Name:" xml:space="preserve">
+    <value>Názov klubu:</value>
+  </data>
+  <data name="Email:" xml:space="preserve">
+    <value>E-mail:</value>
+  </data>
+  <data name="Note:" xml:space="preserve">
+    <value>Poznámka:</value>
+  </data>
+  <data name="Category:" xml:space="preserve">
+    <value>Kategória:</value>
+  </data>
+  <data name="Camping on site:" xml:space="preserve">
+    <value>Kempovanie na mieste:</value>
+  </data>
+  <data name="Interested in T-Shirt of competition for additional 10€:" xml:space="preserve">
+    <value>Má záujem o tričko zo súťaže za príplatok 10 €:</value>
+  </data>
+  <data name="T-Shirt design" xml:space="preserve">
+    <value>Náhľad trička</value>
+  </data>
+  <data name="Select T-Shirt Size:" xml:space="preserve">
+    <value>Vyberte veľkosť trička:</value>
+  </data>
+  <data name="Is Paid:" xml:space="preserve">
+    <value>Zaplatené:</value>
+  </data>
+  <data name="Payment:" xml:space="preserve">
+    <value>Platba:</value>
+  </data>
+  <data name="Do not send registration email:" xml:space="preserve">
+    <value>Neodosielať registračný e-mail:</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Zavrieť</value>
+  </data>
+  <data name="Save changes" xml:space="preserve">
+    <value>Uložiť zmeny</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- inject localization into category, discipline, manager, and thrower management pages and replace hard-coded strings with resource lookups
- localize the general email and thrower edit modals so their labels and actions come from shared resources
- extend all SharedResource *.resx files with the new translations across supported languages

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db92a2e300832ca7c9aaa74083bd8e