### PR TITLE
Localize dialog strings

### DIFF
--- a/CompetitionResults/Components/Shared/BullseyeEditModal.razor
+++ b/CompetitionResults/Components/Shared/BullseyeEditModal.razor
@@ -2,13 +2,14 @@
 @inject DisciplineService DisciplineService
 @inject ThrowerService ThrowerService
 @inject ResultService ResultService
+@inject IStringLocalizer<SharedResource> L
 @inject CompetitionStateService CompetitionState
 
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">Edit Bullseyes for <strong>@thrower.Name @thrower.Surname</strong></h5>
+                <h5 class="modal-title">@L["Edit Bullseyes for"] <strong>@thrower.Name @thrower.Surname</strong></h5>
                 <button type="button" class="btn-close" @onclick="Close"></button>
             </div>
             <div class="modal-body">
@@ -30,8 +31,8 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-                <button type="button" class="btn btn-primary" @onclick="SaveChanges">Save changes</button>
+                <button type="button" class="btn btn-secondary" @onclick="Close">@L["Close"]</button>
+                <button type="button" class="btn btn-primary" @onclick="SaveChanges">@L["Save changes"]</button>
             </div>
         </div>
     </div>

--- a/CompetitionResults/Components/Shared/CategoryEditModal.razor
+++ b/CompetitionResults/Components/Shared/CategoryEditModal.razor
@@ -1,5 +1,6 @@
 ﻿@using CompetitionResults.Data
 @inject CategoryService CategoryService
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
 	<div class="modal-dialog modal-lg">
@@ -8,14 +9,14 @@
 				<DataAnnotationsValidator />
 				<ValidationSummary />
 				<div class="modal-header">
-					<h5 class="modal-title">Edit Category</h5>
+					<h5 class="modal-title">@L["Edit Category"]</h5>
 					<button type="button" class="btn-close" @onclick="Close"></button>
 				</div>
 				<div class="modal-body">
 
 					<div class="form-grid">
 						<div>
-							<label for="name">Name:</label>
+							<label for="name">@L["Name:"]</label>
 							<InputText id="name" @bind-Value="@_category.Name" />
 						</div>
 
@@ -23,8 +24,8 @@
 					</div>
 				</div>
 				<div class="modal-footer">
-					<button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-					<button type="submit" class="btn btn-primary">Save changes</button>
+					<button type="button" class="btn btn-secondary" @onclick="Close">@L["Close"]</button>
+					<button type="submit" class="btn btn-primary">@L["Save changes"]</button>
 				</div>
 			</EditForm>
 		</div>

--- a/CompetitionResults/Components/Shared/CompetitionEditModal.razor
+++ b/CompetitionResults/Components/Shared/CompetitionEditModal.razor
@@ -1,5 +1,6 @@
 ﻿@using CompetitionResults.Data
 @inject CompetitionService CompetitionService
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
 	<div class="modal-dialog modal-lg">
@@ -8,74 +9,74 @@
 				<DataAnnotationsValidator />
 				<ValidationSummary />
 				<div class="modal-header">
-					<h5 class="modal-title">Edit Competition</h5>
+					<h5 class="modal-title">@L["Edit Competition"]</h5>
 					<button type="button" class="btn-close" @onclick="Close"></button>
 				</div>
 				<div class="modal-body">
 
 					<div class="form-grid">
 						<div>
-							<label for="name">Name:</label>
+							<label for="name">@L["Name:"]</label>
 							<InputText id="name" @bind-Value="@_competition.Name" />
 						</div>
 
 						<div>
-							<label for="desc">Description:</label>
+							<label for="desc">@L["Description:"]</label>
 							<InputText id="name" @bind-Value="@_competition.Description" />
 						</div>
 
 						<div>
-							<label for="campingavailable">Camping on site available:</label>
+							<label for="campingavailable">@L["Camping on site available:"]</label>
 							<InputCheckbox id="campingavailable" @bind-Value="@_competition.CampingOnSiteAvailable" />
 						</div>
 
 						<div>
-							<label for="tshirtavailable">T-Shirt available:</label>
+							<label for="tshirtavailable">@L["T-Shirt available:"]</label>
 							<InputCheckbox id="tshirtavailable" @bind-Value="@_competition.TShirtAvailable" />
 						</div>
 
 						<div>
-							<label for="maxThrowers">T-Shirt price EUR:</label>
+							<label for="maxThrowers">@L["T-Shirt price EUR:"]</label>
 							<InputNumber id="priceEUR" @bind-Value="@_competition.TShirtPriceEUR" />
 						</div>
 
 						<div>
-							<label for="maxThrowers">T-Shirt price LOCAL:</label>
+							<label for="maxThrowers">@L["T-Shirt price LOCAL:"]</label>
 							<InputNumber id="priceEUR" @bind-Value="@_competition.TShirtPriceLocal" />
 						</div>
 
 						<div>
-							<label for="tshirtlink">T-Shirt image url (link to picture):</label>
+							<label for="tshirtlink">@L["T-Shirt image url (link to picture):"]</label>
 							<InputText id="tshirtlink" @bind-Value="@_competition.TShirtLink" />
 						</div>
 
 						<div>
-							<label for="emailtemplate">Email template footer english:</label>
+							<label for="emailtemplate">@L["Email template footer english:"]</label>
 							<InputTextArea id="emailtemplate" @bind-Value="@_competition.EmailTemplateFooter" />
 						</div>
 
 						<div>
-							<label for="emailtemplate2">Email template footer local:</label>
+							<label for="emailtemplate2">@L["Email template footer local:"]</label>
 							<InputTextArea id="emailtemplate2" @bind-Value="@_competition.EmailTemplateFooterLocal" />
 						</div>
 
 						<div>
-							<label for="maxThrowers">Maximum number of competitors:</label>
+							<label for="maxThrowers">@L["Maximum number of competitors:"]</label>
 							<InputNumber id="maxThrowers" @bind-Value="@_competition.MaxCompetitorCount" />
 						</div>
 
 						<div>
-							<label for="maxThrowers">Competition price EUR:</label>
+							<label for="maxThrowers">@L["Competition price EUR:"]</label>
 							<InputNumber id="priceEUR" @bind-Value="@_competition.CompetitionPriceEUR" />
 						</div>
 
                         <div>
-                                <label for="maxThrowers">Competition price LOCAL:</label>
+                                <label for="maxThrowers">@L["Competition price LOCAL:"]</label>
                                 <InputNumber id="priceEUR" @bind-Value="@_competition.CompetitionPriceLocal" />
                         </div>
 
                         <div>
-                                <label for="language">Local language (country code):</label>
+                                <label for="language">@L["Local language (country code):"]</label>
                                 <select id="language" @bind="_competition.LocalLanguage">
                                         @foreach (var lang in languages)
                                         {
@@ -87,8 +88,8 @@
 					</div>
 				</div>
 				<div class="modal-footer">
-					<button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-					<button type="submit" class="btn btn-primary">Save changes</button>
+					<button type="button" class="btn btn-secondary" @onclick="Close">@L["Close"]</button>
+					<button type="submit" class="btn btn-primary">@L["Save changes"]</button>
 				</div>
 			</EditForm>
 		</div>

--- a/CompetitionResults/Components/Shared/DisciplineEditModal.razor
+++ b/CompetitionResults/Components/Shared/DisciplineEditModal.razor
@@ -1,5 +1,6 @@
 ﻿@using CompetitionResults.Data
 @inject DisciplineService DisciplineService
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
     <div class="modal-dialog modal-lg">
@@ -8,34 +9,34 @@
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="modal-header">
-                    <h5 class="modal-title">Edit Discipline</h5>
+                    <h5 class="modal-title">@L["Edit Discipline"]</h5>
                     <button type="button" class="btn-close" @onclick="Close"></button>
                 </div>
                 <div class="modal-body">
 
                     <div class="form-grid">
                         <div>
-                            <label for="name">Name:</label>
+                            <label for="name">@L["Name:"]</label>
                             <InputText id="name" @bind-Value="@_discipline.Name" />
                         </div>
                         <div>
-                            <label for="isDividedToCategories">Is Divided To Categories:</label>
+                            <label for="isDividedToCategories">@L["Is Divided To Categories:"]</label>
                             <InputCheckbox id="isDividedToCategories" @bind-Value="_discipline.IsDividedToCategories" />
                         </div>
                         <div>
-                            <label for="hasPositionsInsteadPoints">Has Positions Instead of Points:</label>
+                            <label for="hasPositionsInsteadPoints">@L["Has Positions Instead of Points:"]</label>
                             <InputCheckbox id="hasPositionsInsteadPoints" @bind-Value="_discipline.HasPositionsInsteadPoints" />
                         </div>
                         <div>
-                            <label for="hasDecimalPoints">Has Decimal Points:</label>
+                            <label for="hasDecimalPoints">@L["Has Decimal Points:"]</label>
                             <InputCheckbox id="hasDecimalPoints" @bind-Value="_discipline.HasDecimalPoints" />
                         </div>
 
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-                    <button type="submit" class="btn btn-primary">Save changes</button>
+                    <button type="button" class="btn btn-secondary" @onclick="Close">@L["Close"]</button>
+                    <button type="submit" class="btn btn-primary">@L["Save changes"]</button>
                 </div>
             </EditForm>
         </div>

--- a/CompetitionResults/Components/Shared/ScoreEditModal.razor
+++ b/CompetitionResults/Components/Shared/ScoreEditModal.razor
@@ -3,12 +3,13 @@
 @inject ThrowerService ThrowerService
 @inject ResultService ResultService
 @inject CompetitionStateService CompetitionState
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">Edit Scores for <strong>@thrower.Name @thrower.Surname</strong></h5>
+                <h5 class="modal-title">@L["Edit Scores for"] <strong>@thrower.Name @thrower.Surname</strong></h5>
                 <button type="button" class="btn-close" @onclick="Close"></button>
             </div>
             <div class="modal-body">
@@ -31,8 +32,8 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-                <button type="button" class="btn btn-primary" @onclick="SaveChanges">Save changes</button>
+                <button type="button" class="btn btn-secondary" @onclick="Close">@L["Close"]</button>
+                <button type="button" class="btn btn-primary" @onclick="SaveChanges">@L["Save changes"]</button>
             </div>
         </div>
     </div>

--- a/CompetitionResults/Components/Shared/ThrowerRegistrationModal.razor
+++ b/CompetitionResults/Components/Shared/ThrowerRegistrationModal.razor
@@ -4,6 +4,7 @@
 @inject CompetitionService CompetitionService
 @inject CategoryService CategoryService
 @inject CompetitionStateService CompetitionState
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
 	<div class="modal-dialog modal-lg">
@@ -12,28 +13,28 @@
 				<DataAnnotationsValidator />
 				<ValidationSummary />
 				<div class="modal-header">
-					<h5 class="modal-title">Registration Of Thrower</h5>
+					<h5 class="modal-title">@L["Registration Of Thrower"]</h5>
 					<button type="button" class="btn-close" @onclick="Close"></button>
 				</div>
 				<div class="modal-body">
 					<div class="form-grid">
 						<div>
-							<label for="name">Name:</label>
+							<label for="name">@L["Name:"]</label>
 							<InputText id="name" @bind-Value="@_thrower.Name" />
 						</div>
 
 						<div>
-							<label for="surname">Surname:</label>
+							<label for="surname">@L["Surname:"]</label>
 							<InputText id="surname" @bind-Value="@_thrower.Surname" />
 						</div>
 
 						<div>
-							<label for="nickname">Nickname:</label>
+							<label for="nickname">@L["Nickname:"]</label>
 							<InputText id="nickname" @bind-Value="@_thrower.Nickname" />
 						</div>
 
 						<div>
-							<label for="nationality">Nationality:</label>
+							<label for="nationality">@L["Nationality:"]</label>
 							<select id="nationality" @bind="_thrower.Nationality">
 								@foreach (var country in countries)
 								{
@@ -43,22 +44,22 @@
 						</div>
 
 						<div>
-							<label for="clubName">Club Name:</label>
+							<label for="clubName">@L["Club Name:"]</label>
 							<InputText id="clubName" @bind-Value="@_thrower.ClubName" />
 						</div>
 
 						<div>
-							<label for="email">Email:</label>
+							<label for="email">@L["Email:"]</label>
 							<InputText id="email" @bind-Value="@_thrower.Email" type="email" />
 						</div>
 
 						<div>
-							<label for="note">Note:</label>
+							<label for="note">@L["Note:"]</label>
 							<InputTextArea id="note" @bind-Value="@_thrower.Note" />
 						</div>
 
 						<div>
-							<label for="categoryId">Category:</label>
+							<label for="categoryId">@L["Category:"]</label>
 							<select id="categoryId" @bind="_thrower.CategoryId">
 								@foreach (var category in categories)
 								{
@@ -70,7 +71,7 @@
 						@if (_competition.CampingOnSiteAvailable)
 						{
 							<div>
-								<label for="isCampingOnSite">Camping on site:</label>
+								<label for="isCampingOnSite">@L["Camping on site:"]</label>
 								<InputCheckbox id="isCampingOnSite" @bind-Value="_thrower.IsCampingOnSite" />
 							</div>
 						}
@@ -78,7 +79,7 @@
 						@if (_competition.TShirtAvailable)
 						{
 							<div>
-								<label for="wantTShirt">Interested in T-Shirt of competition for additional 10€:</label>
+								<label for="wantTShirt">@L["Interested in T-Shirt of competition for additional 10€:"]</label>
 								<InputCheckbox id="wantTShirt" @bind-Value="_thrower.WantTShirt" />
 							</div>
 
@@ -86,8 +87,8 @@
 							{
 								<div>
 									<a href="@_competition.TShirtLink" target="_blank">
-										<img src="@_competition.TShirtLink" alt="T-Shirt design" style="width:30px;" />
-										<span>T-Shirt design</span>
+										<img src="@_competition.TShirtLink" alt='@L["T-Shirt design"]' style="width:30px;" />
+										<span>@L["T-Shirt design"]</span>
 									</a>
 								</div>
 							}
@@ -95,7 +96,7 @@
 							@if (_thrower.WantTShirt)
 							{
 								<div>
-									<label for="tShirtSize">Select T-Shirt Size:</label>
+									<label for="tShirtSize">@L["Select T-Shirt Size:"]</label>
 									<InputSelect id="tShirtSize" @bind-Value="_thrower.TShirtSize">
 										<option value="XS">XS</option>
 										<option value="S">S</option>
@@ -113,8 +114,8 @@
 					</div>
 				</div>
 				<div class="modal-footer">
-					<button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-					<button type="submit" class="btn btn-primary">Save changes</button>
+					<button type="button" class="btn btn-secondary" @onclick="Close">@L["Close"]</button>
+					<button type="submit" class="btn btn-primary">@L["Save changes"]</button>
 				</div>
 			</EditForm>
 		</div>

--- a/CompetitionResults/Components/Shared/TranslationEditModal.razor
+++ b/CompetitionResults/Components/Shared/TranslationEditModal.razor
@@ -1,5 +1,6 @@
 @using CompetitionResults.Data
 @inject TranslationService TranslationService
+@inject IStringLocalizer<SharedResource> L
 
 <div class="modal fade @(IsOpen ? "show" : "")" style="display: @(IsOpen ? "block" : "none");">
     <div class="modal-dialog modal-lg">
@@ -8,28 +9,28 @@
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="modal-header">
-                    <h5 class="modal-title">Edit Translation</h5>
+                    <h5 class="modal-title">@L["Edit Translation"]</h5>
                     <button type="button" class="btn-close" @onclick="Close"></button>
                 </div>
                 <div class="modal-body">
                     <div class="form-grid">
                         <div>
-                            <label for="key">Key:</label>
+                            <label for="key">@L["Key:"]</label>
                             <InputText id="key" @bind-Value="@_translation.Key" readonly />
                         </div>
                         <div>
-                            <label for="value">Value:</label>
+                            <label for="value">@L["Value:"]</label>
                             <InputText id="value" @bind-Value="@_translation.Value" />
                         </div>
                         <div>
-                            <label for="language">Language:</label>
+                            <label for="language">@L["Language:"]</label>
                             <InputText id="language" @bind-Value="@_translation.LocalLanguage" readonly />
                         </div>
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-                    <button type="submit" class="btn btn-primary">Save changes</button>
+                    <button type="button" class="btn btn-secondary" @onclick="Close">@L["Close"]</button>
+                    <button type="submit" class="btn btn-primary">@L["Save changes"]</button>
                 </div>
             </EditForm>
         </div>


### PR DESCRIPTION
## Summary
- inject the shared resource localizer into each dialog component
- replace hard-coded titles, labels, and buttons in dialogs with localized strings
- localize remaining UI elements such as the T-shirt design alt text to ensure consistent translations

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb844a050832c9a82b60d91d1d731