### PR TITLE
Add translations for new localization keys

### DIFF
--- a/CompetitionResults/Resources/SharedResource.cs.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.resx
@@ -375,6 +375,9 @@
   <data name="Email:" xml:space="preserve">
     <value>E-mail:</value>
   </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
   <data name="Note:" xml:space="preserve">
     <value>Poznámka:</value>
   </data>
@@ -407,5 +410,89 @@
   </data>
   <data name="Save changes" xml:space="preserve">
     <value>Uložit změny</value>
+  </data>
+  <data name="Registration Of Thrower" xml:space="preserve">
+    <value>Registrace vrhače</value>
+  </data>
+  <data name="Description:" xml:space="preserve">
+    <value>Popis:</value>
+  </data>
+  <data name="Camping on site available:" xml:space="preserve">
+    <value>K dispozici kempování na místě:</value>
+  </data>
+  <data name="T-Shirt available:" xml:space="preserve">
+    <value>Tričko k dispozici:</value>
+  </data>
+  <data name="T-Shirt price EUR:" xml:space="preserve">
+    <value>Cena trička v EUR:</value>
+  </data>
+  <data name="T-Shirt price LOCAL:" xml:space="preserve">
+    <value>Cena trička v místní měně:</value>
+  </data>
+  <data name="T-Shirt image url (link to picture):" xml:space="preserve">
+    <value>URL obrázku trička (odkaz na obrázek):</value>
+  </data>
+  <data name="Email template footer english:" xml:space="preserve">
+    <value>Patička e-mailové šablony anglicky:</value>
+  </data>
+  <data name="Email template footer local:" xml:space="preserve">
+    <value>Patička e-mailové šablony v místním jazyce:</value>
+  </data>
+  <data name="Maximum number of competitors:" xml:space="preserve">
+    <value>Maximální počet soutěžících:</value>
+  </data>
+  <data name="Competition price EUR:" xml:space="preserve">
+    <value>Cena soutěže v EUR:</value>
+  </data>
+  <data name="Competition price LOCAL:" xml:space="preserve">
+    <value>Cena soutěže v místní měně:</value>
+  </data>
+  <data name="Local language (country code):" xml:space="preserve">
+    <value>Místní jazyk (kód země):</value>
+  </data>
+  <data name="Edit Competition" xml:space="preserve">
+    <value>Upravit soutěž</value>
+  </data>
+  <data name="Edit Category" xml:space="preserve">
+    <value>Upravit kategorii</value>
+  </data>
+  <data name="Edit Discipline" xml:space="preserve">
+    <value>Upravit disciplínu</value>
+  </data>
+  <data name="Edit Translation" xml:space="preserve">
+    <value>Upravit překlad</value>
+  </data>
+  <data name="Key:" xml:space="preserve">
+    <value>Klíč:</value>
+  </data>
+  <data name="Value:" xml:space="preserve">
+    <value>Hodnota:</value>
+  </data>
+  <data name="Language:" xml:space="preserve">
+    <value>Jazyk:</value>
+  </data>
+  <data name="Is Divided To Categories:" xml:space="preserve">
+    <value>Je rozdělená do kategorií:</value>
+  </data>
+  <data name="Has Positions Instead of Points:" xml:space="preserve">
+    <value>Má pořadí místo bodů:</value>
+  </data>
+  <data name="Has Decimal Points:" xml:space="preserve">
+    <value>Obsahuje desetinná místa:</value>
+  </data>
+  <data name="Edit Bullseyes for" xml:space="preserve">
+    <value>Upravit bullseye pro</value>
+  </data>
+  <data name="Edit Scores for" xml:space="preserve">
+    <value>Upravit body pro</value>
+  </data>
+  <data name="Clear database" xml:space="preserve">
+    <value>Vymazat databázi</value>
+  </data>
+  <data name="Fill random scores" xml:space="preserve">
+    <value>Vyplnit náhodné výsledky</value>
+  </data>
+  <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
+    <value>Opravdu chcete smazat tuto disciplínu?</value>
   </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.fr.resx
+++ b/CompetitionResults/Resources/SharedResource.fr.resx
@@ -375,6 +375,9 @@
   <data name="Email:" xml:space="preserve">
     <value>E-mail :</value>
   </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
   <data name="Note:" xml:space="preserve">
     <value>Note :</value>
   </data>
@@ -407,5 +410,89 @@
   </data>
   <data name="Save changes" xml:space="preserve">
     <value>Enregistrer les modifications</value>
+  </data>
+  <data name="Registration Of Thrower" xml:space="preserve">
+    <value>Inscription du lanceur</value>
+  </data>
+  <data name="Description:" xml:space="preserve">
+    <value>Description :</value>
+  </data>
+  <data name="Camping on site available:" xml:space="preserve">
+    <value>Camping sur place disponible :</value>
+  </data>
+  <data name="T-Shirt available:" xml:space="preserve">
+    <value>T-shirt disponible :</value>
+  </data>
+  <data name="T-Shirt price EUR:" xml:space="preserve">
+    <value>Prix du t-shirt en EUR :</value>
+  </data>
+  <data name="T-Shirt price LOCAL:" xml:space="preserve">
+    <value>Prix du t-shirt en devise locale :</value>
+  </data>
+  <data name="T-Shirt image url (link to picture):" xml:space="preserve">
+    <value>URL de l'image du t-shirt (lien vers l'image) :</value>
+  </data>
+  <data name="Email template footer english:" xml:space="preserve">
+    <value>Pied de page du modèle d'e-mail en anglais :</value>
+  </data>
+  <data name="Email template footer local:" xml:space="preserve">
+    <value>Pied de page du modèle d'e-mail en langue locale :</value>
+  </data>
+  <data name="Maximum number of competitors:" xml:space="preserve">
+    <value>Nombre maximal de concurrents :</value>
+  </data>
+  <data name="Competition price EUR:" xml:space="preserve">
+    <value>Prix de la compétition en EUR :</value>
+  </data>
+  <data name="Competition price LOCAL:" xml:space="preserve">
+    <value>Prix de la compétition en devise locale :</value>
+  </data>
+  <data name="Local language (country code):" xml:space="preserve">
+    <value>Langue locale (code pays) :</value>
+  </data>
+  <data name="Edit Competition" xml:space="preserve">
+    <value>Modifier la compétition</value>
+  </data>
+  <data name="Edit Category" xml:space="preserve">
+    <value>Modifier la catégorie</value>
+  </data>
+  <data name="Edit Discipline" xml:space="preserve">
+    <value>Modifier la discipline</value>
+  </data>
+  <data name="Edit Translation" xml:space="preserve">
+    <value>Modifier la traduction</value>
+  </data>
+  <data name="Key:" xml:space="preserve">
+    <value>Clé :</value>
+  </data>
+  <data name="Value:" xml:space="preserve">
+    <value>Valeur :</value>
+  </data>
+  <data name="Language:" xml:space="preserve">
+    <value>Langue :</value>
+  </data>
+  <data name="Is Divided To Categories:" xml:space="preserve">
+    <value>Est divisée en catégories :</value>
+  </data>
+  <data name="Has Positions Instead of Points:" xml:space="preserve">
+    <value>Utilise des positions au lieu des points :</value>
+  </data>
+  <data name="Has Decimal Points:" xml:space="preserve">
+    <value>Contient des décimales :</value>
+  </data>
+  <data name="Edit Bullseyes for" xml:space="preserve">
+    <value>Modifier les bullseyes pour</value>
+  </data>
+  <data name="Edit Scores for" xml:space="preserve">
+    <value>Modifier les scores pour</value>
+  </data>
+  <data name="Clear database" xml:space="preserve">
+    <value>Effacer la base de données</value>
+  </data>
+  <data name="Fill random scores" xml:space="preserve">
+    <value>Remplir des scores aléatoires</value>
+  </data>
+  <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir supprimer cette discipline ?</value>
   </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.it.resx
+++ b/CompetitionResults/Resources/SharedResource.it.resx
@@ -375,6 +375,9 @@
   <data name="Email:" xml:space="preserve">
     <value>E-mail:</value>
   </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
   <data name="Note:" xml:space="preserve">
     <value>Nota:</value>
   </data>
@@ -407,5 +410,89 @@
   </data>
   <data name="Save changes" xml:space="preserve">
     <value>Salva modifiche</value>
+  </data>
+  <data name="Registration Of Thrower" xml:space="preserve">
+    <value>Registrazione del lanciatore</value>
+  </data>
+  <data name="Description:" xml:space="preserve">
+    <value>Descrizione:</value>
+  </data>
+  <data name="Camping on site available:" xml:space="preserve">
+    <value>Disponibilità di campeggio in loco:</value>
+  </data>
+  <data name="T-Shirt available:" xml:space="preserve">
+    <value>T-shirt disponibile:</value>
+  </data>
+  <data name="T-Shirt price EUR:" xml:space="preserve">
+    <value>Prezzo della maglietta in EUR:</value>
+  </data>
+  <data name="T-Shirt price LOCAL:" xml:space="preserve">
+    <value>Prezzo della maglietta in valuta locale:</value>
+  </data>
+  <data name="T-Shirt image url (link to picture):" xml:space="preserve">
+    <value>URL immagine della maglietta (link alla foto):</value>
+  </data>
+  <data name="Email template footer english:" xml:space="preserve">
+    <value>Piè di pagina del modello e-mail in inglese:</value>
+  </data>
+  <data name="Email template footer local:" xml:space="preserve">
+    <value>Piè di pagina del modello e-mail in lingua locale:</value>
+  </data>
+  <data name="Maximum number of competitors:" xml:space="preserve">
+    <value>Numero massimo di concorrenti:</value>
+  </data>
+  <data name="Competition price EUR:" xml:space="preserve">
+    <value>Prezzo della competizione in EUR:</value>
+  </data>
+  <data name="Competition price LOCAL:" xml:space="preserve">
+    <value>Prezzo della competizione in valuta locale:</value>
+  </data>
+  <data name="Local language (country code):" xml:space="preserve">
+    <value>Lingua locale (codice paese):</value>
+  </data>
+  <data name="Edit Competition" xml:space="preserve">
+    <value>Modifica competizione</value>
+  </data>
+  <data name="Edit Category" xml:space="preserve">
+    <value>Modifica categoria</value>
+  </data>
+  <data name="Edit Discipline" xml:space="preserve">
+    <value>Modifica disciplina</value>
+  </data>
+  <data name="Edit Translation" xml:space="preserve">
+    <value>Modifica traduzione</value>
+  </data>
+  <data name="Key:" xml:space="preserve">
+    <value>Chiave:</value>
+  </data>
+  <data name="Value:" xml:space="preserve">
+    <value>Valore:</value>
+  </data>
+  <data name="Language:" xml:space="preserve">
+    <value>Lingua:</value>
+  </data>
+  <data name="Is Divided To Categories:" xml:space="preserve">
+    <value>È suddivisa in categorie:</value>
+  </data>
+  <data name="Has Positions Instead of Points:" xml:space="preserve">
+    <value>Ha posizioni invece di punti:</value>
+  </data>
+  <data name="Has Decimal Points:" xml:space="preserve">
+    <value>Ha punti decimali:</value>
+  </data>
+  <data name="Edit Bullseyes for" xml:space="preserve">
+    <value>Modifica bullseye per</value>
+  </data>
+  <data name="Edit Scores for" xml:space="preserve">
+    <value>Modifica punteggi per</value>
+  </data>
+  <data name="Clear database" xml:space="preserve">
+    <value>Cancella il database</value>
+  </data>
+  <data name="Fill random scores" xml:space="preserve">
+    <value>Compila punteggi casuali</value>
+  </data>
+  <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
+    <value>Sei sicuro di voler eliminare questa disciplina?</value>
   </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.ru.resx
+++ b/CompetitionResults/Resources/SharedResource.ru.resx
@@ -375,6 +375,9 @@
   <data name="Email:" xml:space="preserve">
     <value>E-mail:</value>
   </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
   <data name="Note:" xml:space="preserve">
     <value>Примечание:</value>
   </data>
@@ -407,5 +410,89 @@
   </data>
   <data name="Save changes" xml:space="preserve">
     <value>Сохранить изменения</value>
+  </data>
+  <data name="Registration Of Thrower" xml:space="preserve">
+    <value>Регистрация метателя</value>
+  </data>
+  <data name="Description:" xml:space="preserve">
+    <value>Описание:</value>
+  </data>
+  <data name="Camping on site available:" xml:space="preserve">
+    <value>Кемпинг на месте доступен:</value>
+  </data>
+  <data name="T-Shirt available:" xml:space="preserve">
+    <value>Футболка доступна:</value>
+  </data>
+  <data name="T-Shirt price EUR:" xml:space="preserve">
+    <value>Цена футболки в евро:</value>
+  </data>
+  <data name="T-Shirt price LOCAL:" xml:space="preserve">
+    <value>Цена футболки в местной валюте:</value>
+  </data>
+  <data name="T-Shirt image url (link to picture):" xml:space="preserve">
+    <value>URL изображения футболки (ссылка на картинку):</value>
+  </data>
+  <data name="Email template footer english:" xml:space="preserve">
+    <value>Нижний колонтитул шаблона письма (англ.):</value>
+  </data>
+  <data name="Email template footer local:" xml:space="preserve">
+    <value>Нижний колонтитул шаблона письма (местный):</value>
+  </data>
+  <data name="Maximum number of competitors:" xml:space="preserve">
+    <value>Максимальное количество участников:</value>
+  </data>
+  <data name="Competition price EUR:" xml:space="preserve">
+    <value>Стоимость соревнования в евро:</value>
+  </data>
+  <data name="Competition price LOCAL:" xml:space="preserve">
+    <value>Стоимость соревнования в местной валюте:</value>
+  </data>
+  <data name="Local language (country code):" xml:space="preserve">
+    <value>Местный язык (код страны):</value>
+  </data>
+  <data name="Edit Competition" xml:space="preserve">
+    <value>Редактировать соревнование</value>
+  </data>
+  <data name="Edit Category" xml:space="preserve">
+    <value>Редактировать категорию</value>
+  </data>
+  <data name="Edit Discipline" xml:space="preserve">
+    <value>Редактировать дисциплину</value>
+  </data>
+  <data name="Edit Translation" xml:space="preserve">
+    <value>Редактировать перевод</value>
+  </data>
+  <data name="Key:" xml:space="preserve">
+    <value>Ключ:</value>
+  </data>
+  <data name="Value:" xml:space="preserve">
+    <value>Значение:</value>
+  </data>
+  <data name="Language:" xml:space="preserve">
+    <value>Язык:</value>
+  </data>
+  <data name="Is Divided To Categories:" xml:space="preserve">
+    <value>Разделена на категории:</value>
+  </data>
+  <data name="Has Positions Instead of Points:" xml:space="preserve">
+    <value>Использует места вместо очков:</value>
+  </data>
+  <data name="Has Decimal Points:" xml:space="preserve">
+    <value>Имеет десятичные значения:</value>
+  </data>
+  <data name="Edit Bullseyes for" xml:space="preserve">
+    <value>Редактировать буллзай для</value>
+  </data>
+  <data name="Edit Scores for" xml:space="preserve">
+    <value>Редактировать результаты для</value>
+  </data>
+  <data name="Clear database" xml:space="preserve">
+    <value>Очистить базу данных</value>
+  </data>
+  <data name="Fill random scores" xml:space="preserve">
+    <value>Заполнить случайные результаты</value>
+  </data>
+  <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
+    <value>Вы уверены, что хотите удалить эту дисциплину?</value>
   </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.sk.resx
+++ b/CompetitionResults/Resources/SharedResource.sk.resx
@@ -375,6 +375,9 @@
   <data name="Email:" xml:space="preserve">
     <value>E-mail:</value>
   </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
   <data name="Note:" xml:space="preserve">
     <value>Poznámka:</value>
   </data>
@@ -407,5 +410,89 @@
   </data>
   <data name="Save changes" xml:space="preserve">
     <value>Uložiť zmeny</value>
+  </data>
+  <data name="Registration Of Thrower" xml:space="preserve">
+    <value>Registrácia vrhača</value>
+  </data>
+  <data name="Description:" xml:space="preserve">
+    <value>Popis:</value>
+  </data>
+  <data name="Camping on site available:" xml:space="preserve">
+    <value>K dispozícii kempovanie na mieste:</value>
+  </data>
+  <data name="T-Shirt available:" xml:space="preserve">
+    <value>Tričko k dispozícii:</value>
+  </data>
+  <data name="T-Shirt price EUR:" xml:space="preserve">
+    <value>Cena trička v EUR:</value>
+  </data>
+  <data name="T-Shirt price LOCAL:" xml:space="preserve">
+    <value>Cena trička v miestnej mene:</value>
+  </data>
+  <data name="T-Shirt image url (link to picture):" xml:space="preserve">
+    <value>URL obrázka trička (odkaz na obrázok):</value>
+  </data>
+  <data name="Email template footer english:" xml:space="preserve">
+    <value>Pätička e-mailovej šablóny v angličtine:</value>
+  </data>
+  <data name="Email template footer local:" xml:space="preserve">
+    <value>Pätička e-mailovej šablóny v miestnom jazyku:</value>
+  </data>
+  <data name="Maximum number of competitors:" xml:space="preserve">
+    <value>Maximálny počet súťažiacich:</value>
+  </data>
+  <data name="Competition price EUR:" xml:space="preserve">
+    <value>Cena súťaže v EUR:</value>
+  </data>
+  <data name="Competition price LOCAL:" xml:space="preserve">
+    <value>Cena súťaže v miestnej mene:</value>
+  </data>
+  <data name="Local language (country code):" xml:space="preserve">
+    <value>Miestny jazyk (kód krajiny):</value>
+  </data>
+  <data name="Edit Competition" xml:space="preserve">
+    <value>Upraviť súťaž</value>
+  </data>
+  <data name="Edit Category" xml:space="preserve">
+    <value>Upraviť kategóriu</value>
+  </data>
+  <data name="Edit Discipline" xml:space="preserve">
+    <value>Upraviť disciplínu</value>
+  </data>
+  <data name="Edit Translation" xml:space="preserve">
+    <value>Upraviť preklad</value>
+  </data>
+  <data name="Key:" xml:space="preserve">
+    <value>Kľúč:</value>
+  </data>
+  <data name="Value:" xml:space="preserve">
+    <value>Hodnota:</value>
+  </data>
+  <data name="Language:" xml:space="preserve">
+    <value>Jazyk:</value>
+  </data>
+  <data name="Is Divided To Categories:" xml:space="preserve">
+    <value>Je rozdelená do kategórií:</value>
+  </data>
+  <data name="Has Positions Instead of Points:" xml:space="preserve">
+    <value>Má poradia namiesto bodov:</value>
+  </data>
+  <data name="Has Decimal Points:" xml:space="preserve">
+    <value>Obsahuje desatinné miesta:</value>
+  </data>
+  <data name="Edit Bullseyes for" xml:space="preserve">
+    <value>Upraviť bullseye pre</value>
+  </data>
+  <data name="Edit Scores for" xml:space="preserve">
+    <value>Upraviť body pre</value>
+  </data>
+  <data name="Clear database" xml:space="preserve">
+    <value>Vymazať databázu</value>
+  </data>
+  <data name="Fill random scores" xml:space="preserve">
+    <value>Vyplniť náhodné výsledky</value>
+  </data>
+  <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
+    <value>Naozaj chcete odstrániť túto disciplínu?</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- add translations for the newly used localization keys in Czech, French, Italian, Russian, and Slovak resource files

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbbadfbf0c832c803df5b357db7508