### PR TITLE
Localize remaining Razor strings

### DIFF
--- a/CompetitionResults/Components/Pages/Administration.razor
+++ b/CompetitionResults/Components/Pages/Administration.razor
@@ -9,20 +9,21 @@
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject CompetitionService CompetitionService
 @inject CompetitionStateService CompetitionState
-<h3>Administration</h3>
+@inject IStringLocalizer<SharedResource> L
+<h3>@L["Administration"]</h3>
 <AuthorizeView Roles="Admin, Manager, User">
 	<Authorized>
 		@if (@context.User.IsInRole(ADMINISTRATION_ROLE) || @context.User.IsInRole(MANAGER_ROLE) || @context.User.IsInRole(USER_ROLE))
 		{
-			<table class="table">
-				<thead>
-					<tr>
-						<th>Id</th>
-						<th>User Name</th>
-						<th>Email</th>
-						<th>Action</th>
-					</tr>
-				</thead>
+                        <table class="table">
+                                <thead>
+                                        <tr>
+                                                <th>@L["Id"]</th>
+                                                <th>@L["User Name"]</th>
+                                                <th>@L["Email"]</th>
+                                                <th>@L["Action"]</th>
+                                        </tr>
+                                </thead>
 				<tbody>
 					@foreach (var user in ColUsers)
 					{
@@ -32,10 +33,10 @@
 							<td>@user.Email</td>
 							<td>
 								<!-- Edit the current forecast -->
-								<button class="btn btn-primary"
-										@onclick="(() => EditUser(user))">
-									Edit
-								</button>
+                                                                <button class="btn btn-primary"
+                                                                                @onclick="(() => EditUser(user))">
+                                                                        @L["Edit"]
+                                                                </button>
 							</td>
 						</tr>
 					}
@@ -49,7 +50,7 @@
 					<div class="modal-dialog">
 						<div class="modal-content">
 							<div class="modal-header">
-								<h3 class="modal-title">Edit User</h3>
+                                                                <h3 class="modal-title">@L["Edit User"]</h3>
 								<!-- Button to close the popup -->
 								<button type="button" class="close"
 										@onclick="ClosePopup">
@@ -70,16 +71,16 @@
 								}
 								else
 								{
-									<input class="form-control" type="text"
-										   placeholder="UserName"
-										   @bind="objUser.UserName" />
-								}
-								<input class="form-control" type="text"
-									   placeholder="Email"
-									   @bind="objUser.Email" />
-								<input class="form-control" type="password"
-									   placeholder="Password"
-									   @bind="objUser.PasswordHash" />
+                                                                        <input class="form-control" type="text"
+                                                                                   placeholder='@L["User Name"]'
+                                                                                   @bind="objUser.UserName" />
+                                                                }
+                                                                <input class="form-control" type="text"
+                                                                           placeholder='@L["Email"]'
+                                                                           @bind="objUser.Email" />
+                                                                <input class="form-control" type="password"
+                                                                           placeholder='@L["Password"]'
+                                                                           @bind="objUser.PasswordHash" />
 								<select class="form-control"
 										@bind="@CurrentUserRole">
 									@foreach (var option in Options)
@@ -91,18 +92,18 @@
 								</select>
 								<br /><br />
 								<!-- Button to save the user -->
-								<button class="btn btn-primary"
-										@onclick="SaveUser">
-									Save
-								</button>
+                                                                <button class="btn btn-primary"
+                                                                                @onclick="SaveUser">
+                                                                        @L["Save"]
+                                                                </button>
 								<!-- Only show delete button if not a new record -->
 								@if (objUser.Id != "")
 								{
 									<!-- Button to delete the forecast -->
-									<button class="btn btn-danger"
-											@onclick="DeleteUser">
-										Delete
-									</button>
+                                                                        <button class="btn btn-danger"
+                                                                                        @onclick="DeleteUser">
+                                                                                @L["Delete"]
+                                                                        </button>
 								}
 								<br />
 								<span style="color:red">@strError</span>
@@ -113,17 +114,17 @@
 			}
 			@if (@context.User.IsInRole(ADMINISTRATION_ROLE) || @context.User.IsInRole(MANAGER_ROLE))
 			{
-				<button class="btn btn-success" @onclick="AddNewUser">Add User</button>
+                                <button class="btn btn-success" @onclick="AddNewUser">@L["Add User"]</button>
 			}
 		}
 		else
 		{
-			<p>You're not signed in as a user in @ADMINISTRATION_ROLE.</p>
-		}
-	</Authorized>
-	<NotAuthorized>
-		<p>You're not loggged in.</p>
-	</NotAuthorized>
+                        <p>@string.Format(L["You're not signed in as a user in {0}."]!, ADMINISTRATION_ROLE)</p>
+                }
+        </Authorized>
+        <NotAuthorized>
+                <p>@L["You're not logged in."]</p>
+        </NotAuthorized>
 </AuthorizeView>
 @code {
 	// Property used to add or edit the currently selected user

--- a/CompetitionResults/Components/Pages/Error.cshtml
+++ b/CompetitionResults/Components/Pages/Error.cshtml
@@ -1,13 +1,18 @@
-﻿@page
+@page
+@using CompetitionResults
+@using Microsoft.AspNetCore.Components
+@using Microsoft.Extensions.Localization
+@using System.Globalization
 @model CompetitionResults.Pages.ErrorModel
+@inject IStringLocalizer<SharedResource> L
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="@CultureInfo.CurrentUICulture.Name">
 
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>Error</title>
+    <title>@L["Error"]</title>
     <link href="~/css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="~/css/site.css" rel="stylesheet" asp-append-version="true" />
 </head>
@@ -15,25 +20,24 @@
 <body>
     <div class="main">
         <div class="content px-4">
-            <h1 class="text-danger">Error.</h1>
-            <h2 class="text-danger">An error occurred while processing your request.</h2>
+            <h1 class="text-danger">@L["Error."]</h1>
+            <h2 class="text-danger">@L["An error occurred while processing your request."]</h2>
 
             @if (Model.ShowRequestId)
             {
                 <p>
-                    <strong>Request ID:</strong> <code>@Model.RequestId</code>
+                    <strong>@L["Request ID:"]</strong> <code>@Model.RequestId</code>
                 </p>
             }
 
-            <h3>Development Mode</h3>
+            <h3>@L["Development Mode"]</h3>
             <p>
-                Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
+                @((MarkupString)L["Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred."].Value)
             </p>
             <p>
-                <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-                It can result in displaying sensitive information from exceptions to end users.
-                For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-                and restarting the app.
+                @((MarkupString)L["<strong>The Development environment shouldn't be enabled for deployed applications.</strong>"].Value)
+                @L["It can result in displaying sensitive information from exceptions to end users."]
+                @((MarkupString)L["For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong> and restarting the app."].Value)
             </p>
         </div>
     </div>

--- a/CompetitionResults/Components/Pages/MedalsByNation.razor
+++ b/CompetitionResults/Components/Pages/MedalsByNation.razor
@@ -5,27 +5,28 @@
 @inject DisciplineService DisciplineService
 @inject CategoryService CategoryService
 @inject CompetitionStateService CompetitionState
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Medals by Nation</h3>
+<h3>@L["Medals by nation"]</h3>
 
 @if (medals == null)
 {
-    <p>Loading...</p>
+    <p>@L["Loading..."]</p>
 }
 else if (!medals.Any())
 {
-    <p>No medals found.</p>
+    <p>@L["No medals found."]</p>
 }
 else
 {
     <table class="table table-striped">
         <thead>
             <tr>
-                <th>Nation</th>
-                <th>🥇 Gold</th>
-                <th>🥈 Silver</th>
-                <th>🥉 Bronze</th>
-                <th>Total</th>
+                <th>@L["Nation"]</th>
+                <th>🥇 @L["Gold"]</th>
+                <th>🥈 @L["Silver"]</th>
+                <th>🥉 @L["Bronze"]</th>
+                <th>@L["Total"]</th>
             </tr>
         </thead>
         <tbody>

--- a/CompetitionResults/Components/Pages/Registration.razor
+++ b/CompetitionResults/Components/Pages/Registration.razor
@@ -7,14 +7,15 @@
 @inject CompetitionService CompetitionService
 @implements IDisposable
 @inject IJSRuntime JSRuntime
+@inject IStringLocalizer<SharedResource> L
 
 @if (!IsFull(CompetitionState.SelectedCompetitionId))
 {
-    <button @onclick="AddNew">Register</button>
+    <button @onclick="AddNew">@L["Register"]</button>
 }
 else
 {
-    <label >Registration is full!</label>
+    <label>@L["Registration is full!"]</label>
 }
 
 <ThrowerRegistrationModal @ref="throwerRegistrationModal" OnClose="HandleModalClose" Thrower="selectedThrower" OnFormSubmit="HandleFormSubmit" />
@@ -28,7 +29,7 @@ else
 
 @if (throwers == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else
 {
@@ -41,17 +42,17 @@ else
 
     <h3>@competitionDesc</h3>
 
-    <h3>Registered throwers</h3>
+    <h3>@L["Registered throwers"]</h3>
     <table class="table">
         <thead>
             <tr>
                 <th>#</th>
-                <th>Name</th>
-                <th>Surname</th>
-                <th>Nationality</th>
-                <th>Flag</th>
-                <th>Club Name</th>
-                <th>Payment done</th>
+                <th>@L["Name"]</th>
+                <th>@L["Surname"]</th>
+                <th>@L["Nationality"]</th>
+                <th>@L["Flag"]</th>
+                <th>@L["Club Name"]</th>
+                <th>@L["Payment done"]</th>
             </tr>
         </thead>
         <tbody>
@@ -72,7 +73,7 @@ else
                              style="height:20px; width:30px;" />
                     </td>
                     <td>@thrower.ClubName</td>
-                    <td style="background-color: @(!thrower.PaymentDone ? "red" : "white");">@(!thrower.PaymentDone ? "No" : "Yes")</td>
+                    <td style="background-color: @(!thrower.PaymentDone ? "red" : "white");">@(!thrower.PaymentDone ? L["No"] : L["Yes"])</td>
                 </tr>
             }
         </tbody>
@@ -80,7 +81,7 @@ else
 
     <div style="margin-top: 20px;">
         <p>
-            <h4>Total countries: @countryCount</h4>
+            <h4>@string.Format(L["Total countries: {0}"]!, countryCount)</h4>
             @foreach (var country in countryFlags)
             {
                 var flagUrl = $"https://flagcdn.com/32x24/{country}.png";
@@ -88,7 +89,7 @@ else
             }
         </p>
 
-        <h4>Categories:</h4>
+        <h4>@L["Categories:"]</h4>
         <ul>
             @foreach (var category in categoriesDict)
             {
@@ -97,10 +98,10 @@ else
         </ul>
 
         <p>
-            <h4>Total campers: @campersCount</h4>
+            <h4>@string.Format(L["Total campers: {0}"]!, campersCount)</h4>
         </p>
 
-        <h4>T-shirts:</h4>
+        <h4>@L["T-shirts:"]</h4>
         <ul>
             @foreach (var tshirt in tshirtDict)
             {

--- a/CompetitionResults/Components/Pages/Results.razor
+++ b/CompetitionResults/Components/Pages/Results.razor
@@ -7,11 +7,12 @@
 @inject CompetitionStateService CompetitionState
 @inject NavigationManager Navigation
 @inject IJSRuntime JSRuntime
+@inject IStringLocalizer<SharedResource> L
 @implements IAsyncDisposable
 
-		@if (disciplines == null || categories == null)
-		{
-			<p><em>Loading...</em></p>
+                @if (disciplines == null || categories == null)
+                {
+                        <p><em>@L["Loading..."]</em></p>
 		}
 		else
 		{
@@ -32,7 +33,7 @@
 						<button @onclick='() => ShowResults(0, discipline.Id)' class="m-2">@discipline.Name</button>
 					}
 
-					<button @onclick='() => ShowResults(0, 0)' class="m-2">Total winner</button>
+                                        <button @onclick='() => ShowResults(0, 0)' class="m-2">@L["Total winner"]</button>
 				</div>
 			</div>
 
@@ -50,9 +51,9 @@
 								var points = selectedCategoryId != 0 ? GetResultValueForDiscipline(selectedCategoryId, selectedDisciplineId, i) : GetResultValueForDisciplineOverall(selectedDisciplineId, i);
 								var awardPoints = selectedCategoryId != 0 ? GetAwardValueForDiscipline(selectedCategoryId, selectedDisciplineId, i) : GetAwardValueForDisciplineOverall(selectedDisciplineId, i);
 
-						ResultDto? result = new ResultDto
-						{
-							ThrowerName = "N/A",
+                                                ResultDto? result = new ResultDto
+                                                {
+                                                        ThrowerName = L["N/A"],
 							Points = null,
 							BullseyeCount = null
 						};
@@ -74,22 +75,22 @@
 
 
                                                                 <div class="result-card m-2 p-2 border rounded" style="@result.BackgroundColor">
-									<div class="rank">Rank: @(i + 1)</div>
-									<div class="thrower-name"><strong>@throwerName</strong></div>
-									<div class="points">Points: @points
-										 @if (result.BullseyeCount.HasValue)
-											{
-												<span> (@result.BullseyeCount)</span>
-											}
-									</div>
-									<div class="award-points">Award Points: @awardPoints</div>
+                                                                        <div class="rank">@L["Rank"]: @(i + 1)</div>
+                                                                        <div class="thrower-name"><strong>@throwerName</strong></div>
+                                                                        <div class="points">@L["Points"]: @points
+                                                                                 @if (result.BullseyeCount.HasValue)
+                                                                                        {
+                                                                                                <span> (@result.BullseyeCount)</span>
+                                                                                        }
+                                                                        </div>
+                                                                        <div class="award-points">@L["Award Points"]: @awardPoints</div>
 								</div>
 							}
 						</div>
 					}
 					else if (MaxResultsCount() > 0)
 					{
-						<h3 class="mb-1 p-0">Total winner</h3>
+                                                <h3 class="mb-1 p-0">@L["Total winner"]</h3>
 						<div class="d-flex flex-wrap">
 							@for (int i = 0; i < MaxResultsCount(); i++)
 							{
@@ -102,15 +103,15 @@
 									: resultsOverallDictionary[selectedDisciplineId][i];
 
                                                                 <div class="result-card m-2 p-2 border rounded" style="@result.BackgroundColor">
-									<div class="rank">Rank: @(i + 1)</div>
-									<div class="thrower-name"><strong>@throwerName</strong></div>
-									<div class="points">Points: @points
-										 @if (result.BullseyeCount.HasValue)
-											{
-												<span> (@result.BullseyeCount)</span>
-											}
-									</div>
-									<div class="award-points">Award Points: @awardPoints</div>
+                                                                        <div class="rank">@L["Rank"]: @(i + 1)</div>
+                                                                        <div class="thrower-name"><strong>@throwerName</strong></div>
+                                                                        <div class="points">@L["Points"]: @points
+                                                                                 @if (result.BullseyeCount.HasValue)
+                                                                                        {
+                                                                                                <span> (@result.BullseyeCount)</span>
+                                                                                        }
+                                                                        </div>
+                                                                        <div class="award-points">@L["Award Points"]: @awardPoints</div>
 								</div>
 							}
 						</div>
@@ -214,7 +215,7 @@
 				return results[position].ThrowerName;
 			}
 		}
-		return "N/A";
+                return L["N/A"];
 	}
 
 	private double? GetResultValueForDiscipline(int categoryId, int disciplineId, int position)
@@ -266,7 +267,7 @@
 				return results[position].ThrowerName;
 			}
 		}
-		return "N/A";
+                return L["N/A"];
 	}
 
 	private double? GetResultValueForDisciplineOverall(int disciplineId, int position)

--- a/CompetitionResults/Components/Pages/ResultsByCountry.razor
+++ b/CompetitionResults/Components/Pages/ResultsByCountry.razor
@@ -1,27 +1,29 @@
 @page "/resultsbycountry"
 @using CompetitionResults.Data
+@using Microsoft.AspNetCore.Components
 @inject ResultService ResultsService
 @inject ThrowerService ThrowerService
 @inject DisciplineService DisciplineService
 @inject CategoryService CategoryService
 @inject CompetitionStateService CompetitionState
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Results by Country</h3>
+<h3>@L["Results by country"]</h3>
 
 @if (isLoading)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else if (loadError != null)
 {
-    <div class="alert alert-danger">@loadError</div>
+    <div class="alert alert-danger">@string.Format(L["Failed to load results: {0}"], loadError)</div>
 }
 else
 {
     <div class="mb-3">
-        <label for="countrySelect" class="form-label fw-semibold">Country</label>
+        <label for="countrySelect" class="form-label fw-semibold">@L["Country"]</label>
         <select id="countrySelect" class="form-select" @bind="selectedCountry">
-            <option value="">All countries</option>
+            <option value="">@L["All countries"]</option>
             @foreach (var c in countries)
             {
                 <option value="@c">@c</option>
@@ -29,7 +31,7 @@ else
         </select>
         @if (!string.IsNullOrEmpty(selectedCountry))
         {
-            <div class="mt-2 small text-muted">Showing only throwers from <strong>@selectedCountry</strong>.</div>
+            <div class="mt-2 small text-muted">@((MarkupString)string.Format(L["Showing only throwers from {0}."]!, $"<strong>{selectedCountry}</strong>"))</div>
         }
     </div>
 
@@ -42,7 +44,7 @@ else
             <div class="card-body p-0">
                 @if (!resultsByDiscipline.TryGetValue(disc.Id, out var results) || results == null || results.Count == 0)
                 {
-                    <div class="p-3 text-muted"><em>No results.</em></div>
+                    <div class="p-3 text-muted"><em>@L["No results."]</em></div>
                 }
                 else
                 {
@@ -54,7 +56,7 @@ else
 
                     if (filtered.Count == 0)
                     {
-                        <div class="p-3 text-muted"><em>No results for @selectedCountry.</em></div>
+                        <div class="p-3 text-muted"><em>@string.Format(L["No results for {0}."]!, selectedCountry)</em></div>
                     }
                     else
                     {
@@ -62,9 +64,9 @@ else
                             <table class="table table-sm table-striped mb-0 align-middle">
                                 <thead class="table-light">
                                     <tr>
-                                        <th style="width:64px;">Rank</th>
-                                        <th>Thrower</th>
-                                        <th class="text-end" style="width:120px;">Points</th>
+                                        <th style="width:64px;">@L["Rank"]</th>
+                                        <th>@L["Thrower"]</th>
+                                        <th class="text-end" style="width:120px;">@L["Points"]</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/CompetitionResults/Components/Pages/ResultsListStatic.razor
+++ b/CompetitionResults/Components/Pages/ResultsListStatic.razor
@@ -8,21 +8,22 @@
 @inject NavigationManager Navigation
 @inject IJSRuntime JSRuntime
 @implements IAsyncDisposable
+@inject IStringLocalizer<SharedResource> L
 
 
-		@if (disciplines == null || categories == null)
-		{
-			<p><em>Loading...</em></p>
-		}
-		else
-		{
+                @if (disciplines == null || categories == null)
+                {
+                        <p><em>@L["Loading..."]</em></p>
+                }
+                else
+                {
 			<div class="container m-0 p-0 small-font row">
 				<div class="col-12">
 					@foreach (var category in categories)
 					{
 						if (MaxResultsCount(category.Id) >= 1)
 						{
-							<button @onclick='() => ExportAsPDF("resultContent" + category.Id)' class="m-2">Export to PDF</button>
+                                                        <button @onclick='() => ExportAsPDF("resultContent" + category.Id)' class="m-2">@L["Export to PDF"]</button>
 
 							<div id="resultContent@(category.Id)">
 								<h7 class="mb-1 p-0">@category.Name</h7>
@@ -30,7 +31,7 @@
 								<table class="table table-hover table-bordered m-0 p-0 mb-1">
 									<thead class="thead-light">
 										<tr>
-											<th style="width: 30px;">Rank</th>
+                                                                                        <th style="width: 30px;">@L["Rank"]</th>
 											@foreach (var discipline in disciplines.Where(d => d.IsDividedToCategories))
 											{
 												<th>@discipline.Name</th>
@@ -77,16 +78,16 @@
 
 			<div class="container m-0 p-0 small-font row">
 				<div class="col-12">
-					<button @onclick='() => ExportAsPDF("resultContent")' class="m-2">Export to PDF</button>
+                                        <button @onclick='() => ExportAsPDF("resultContent")' class="m-2">@L["Export to PDF"]</button>
 
-					<div id="resultContent">
-						<h7 class="mb-1 p-0">Overall</h7>
+                                        <div id="resultContent">
+                                                <h7 class="mb-1 p-0">@L["Overall"]</h7>
 
 						<table class="table table-hover table-bordered m-0 p-0 mb-1">
 							<thead class="thead-light">
 								<tr>
-									<th style="width: 30px;">Rank</th>
-									<th>Total Winner</th>
+                                                                        <th style="width: 30px;">@L["Rank"]</th>
+                                                                        <th>@L["Total winner"]</th>
 									@foreach (var discipline in disciplines.Where(d => !d.IsDividedToCategories).OrderBy(d => d.HasPositionsInsteadPoints).ThenBy(d => d.Id).Take(6))
 									{
 										<th>@discipline.Name</th>
@@ -138,15 +139,15 @@
 			{
 			<div class="container m-0 p-0 small-font row">
 				<div class="col-12">
-					<button @onclick='() => ExportAsPDF("resultContentTwo")' class="m-2">Export to PDF</button>
+                                        <button @onclick='() => ExportAsPDF("resultContentTwo")' class="m-2">@L["Export to PDF"]</button>
 
-					<div id="resultContentTwo">
-						<h7 class="mb-1 p-0">Overall 2</h7>
+                                        <div id="resultContentTwo">
+                                                <h7 class="mb-1 p-0">@L["Overall 2"]</h7>
 
 						<table class="table table-hover table-bordered m-0 p-0 mb-1">
 							<thead class="thead-light">
 								<tr>
-									<th style="width: 30px;">Rank</th>
+                                                                        <th style="width: 30px;">@L["Rank"]</th>
 									@foreach (var discipline in disciplines.Where(d => !d.IsDividedToCategories).OrderBy(d => d.HasPositionsInsteadPoints).ThenBy(d => d.Id).Skip(6))
 									{
 										<th>@discipline.Name</th>

--- a/CompetitionResults/Components/Pages/ResultsSelectable.razor
+++ b/CompetitionResults/Components/Pages/ResultsSelectable.razor
@@ -7,15 +7,16 @@
 @inject CompetitionStateService CompetitionState
 @inject NavigationManager Navigation
 @implements IAsyncDisposable
+@inject IStringLocalizer<SharedResource> L
 
-		@if (disciplines == null || categories == null)
-		{
-			<p><em>Loading...</em></p>
-		}
-		else
-		{
-			<div class="container small-font">
-				<h6 class="mb-2">Select Disciplines to Display</h6>
+                @if (disciplines == null || categories == null)
+                {
+                        <p><em>@L["Loading..."]</em></p>
+                }
+                else
+                {
+                        <div class="container small-font">
+                                <h6 class="mb-2">@L["Select disciplines to display"]</h6>
 
 				<div class="d-flex flex-wrap mb-2">
 					@foreach (var category in categories)
@@ -56,10 +57,10 @@
 					var allColumns = selectedGroupedDisciplines.Cast<object>().Concat(selectedOverallDisciplines.Cast<object>()).ToList();
 
 					<div class="table-responsive">
-						<table class="table table-hover table-bordered m-0 p-0">
-							<thead class="thead-light">
-								<tr>
-									<th style="width: 30px;">Rank</th>
+                                                <table class="table table-hover table-bordered m-0 p-0">
+                                                        <thead class="thead-light">
+                                                                <tr>
+                                                                        <th style="width: 30px;">@L["Rank"]</th>
 
 									@foreach (var key in selectedGroupedDisciplines)
 									{

--- a/CompetitionResults/Components/Pages/ResultsThrower.razor
+++ b/CompetitionResults/Components/Pages/ResultsThrower.razor
@@ -5,12 +5,13 @@
 @inject DisciplineService DisciplineService
 @inject CategoryService CategoryService
 @inject CompetitionStateService CompetitionState
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Results by Thrower</h3>
+<h3>@L["Results by thrower"]</h3>
 
 @if (throwers == null || disciplines == null || categories == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else
 {
@@ -26,7 +27,7 @@ else
     @if (selectedThrowerResults != null)
     {
         var thrower = throwers.First(t => t.Id == selectedThrowerId);
-        <h4>Results for @thrower.Name</h4>
+        <h4>@string.Format(L["Results for {0}"]!, thrower.Name)</h4>
 
         <div class="d-flex flex-wrap">
             @foreach (var group in selectedThrowerResults
@@ -48,16 +49,16 @@ else
                     var category = categories.FirstOrDefault(c => c.Id == result.CategoryId);
 
                     <div class="result-card m-2 p-2 border rounded" style="@result.BackgroundColor">
-                        <div><strong>Discipline:</strong> @disciplineName</div>
+                        <div><strong>@L["Discipline:"]</strong> @disciplineName</div>
                         @if (isDivided && category != null)
                         {
-                            <div><strong>Category:</strong> @category.Name</div>
+                            <div><strong>@L["Category:"]</strong> @category.Name</div>
                         }
                         @if (result.Position > 0)
                         {
-                            <div><strong>Position:</strong> @result.Position</div>
+                            <div><strong>@L["Position:"]</strong> @result.Position</div>
                         }
-                        <div><strong>Points:</strong> @result.Points @if (result.BullseyeCount.HasValue) { <span>(@result.BullseyeCount)</span> }</div>
+                        <div><strong>@L["Points:"]</strong> @result.Points @if (result.BullseyeCount.HasValue) { <span>(@result.BullseyeCount)</span> }</div>
                     </div>
                 }
             }

--- a/CompetitionResults/Components/Pages/ScoresList.razor
+++ b/CompetitionResults/Components/Pages/ScoresList.razor
@@ -8,12 +8,13 @@
 @inject ResultService ResultService
 @inject CompetitionStateService CompetitionState
 @implements IDisposable
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Scores List</h3>
+<h3>@L["Scores List"]</h3>
 <div>
-    <input class="form-control d-inline-block me-2" style="width: 120px;" placeholder="#"
-           @bind="filterId" @bind:event="oninput" />
-    <input class="form-control d-inline-block" style="width: 200px;" placeholder="Name"
+    <input class="form-control d-inline-block me-2" style="width: 120px;" placeholder='@L["Start number"]'
+            @bind="filterId" @bind:event="oninput" />
+    <input class="form-control d-inline-block" style="width: 200px;" placeholder='@L["Name"]'
            @bind="filterName" @bind:event="oninput" />
 </div>
 <AuthorizeView Roles="Admin, Manager, User">
@@ -25,7 +26,7 @@
 
 @if (throwers == null || disciplines == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else
 {
@@ -33,9 +34,9 @@ else
         <thead>
             <tr>
                 <th>#</th>
-                <th>Name</th>
-                        <th>Edit</th>
-                        <th>Bullseyes</th>
+                <th>@L["Name"]</th>
+                        <th>@L["Edit"]</th>
+                        <th>@L["Bullseyes"]</th>
                 @foreach (var discipline in disciplines)
                 {
                     <th>@discipline.Name</th>
@@ -54,10 +55,10 @@ else
                                 }
                     </td>
                             <td>
-                                <button @onclick="() => EditScores(thrower)">Edit</button>
+                                <button @onclick="() => EditScores(thrower)">@L["Edit"]</button>
                             </td>
                             <td>
-                                <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => EditBullseyes(thrower)">Bullseyes</button>
+                                <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => EditBullseyes(thrower)">@L["Bullseyes"]</button>
                             </td>
                     @foreach (var discipline in disciplines)
                     {
@@ -74,7 +75,7 @@ else
 
     </Authorized>
     <NotAuthorized>
-        <p>You're not loggged in.</p>
+        <p>@L["You're not logged in."]</p>
     </NotAuthorized>
 </AuthorizeView>
 

--- a/CompetitionResults/Components/Pages/TranslationsList.razor
+++ b/CompetitionResults/Components/Pages/TranslationsList.razor
@@ -6,8 +6,9 @@
 @inject CompetitionStateService CompetitionState
 @inject IJSRuntime JSRuntime
 @implements IDisposable
+@inject IStringLocalizer<SharedResource> L
 
-<h3>Translations</h3>
+<h3>@L["Translations"]</h3>
 
 <AuthorizeView Roles="Admin, Manager">
     <Authorized>
@@ -15,16 +16,16 @@
 
         @if (translations == null)
         {
-            <p><em>Loading...</em></p>
+            <p><em>@L["Loading..."]</em></p>
         }
         else
         {
             <table class="table">
                 <thead>
                     <tr>
-                        <th>Key</th>
-                        <th>Value</th>
-                        <th>Actions</th>
+                        <th>@L["Key"]</th>
+                        <th>@L["Value"]</th>
+                        <th>@L["Actions"]</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -34,7 +35,7 @@
                             <td>@tr.Key</td>
                             <td>@tr.Value</td>
                             <td>
-                                <button @onclick="() => EditTranslation(tr)">Edit</button>
+                                <button @onclick="() => EditTranslation(tr)">@L["Edit"]</button>
                             </td>
                         </tr>
                     }
@@ -43,7 +44,7 @@
         }
     </Authorized>
     <NotAuthorized>
-        <p>You're not loggged in.</p>
+        <p>@L["You're not logged in."]</p>
     </NotAuthorized>
 </AuthorizeView>
 

--- a/CompetitionResults/Resources/SharedResource.cs.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.resx
@@ -495,4 +495,166 @@
   <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
     <value>Opravdu chcete smazat tuto disciplínu?</value>
   </data>
+  <data name="Total winner" xml:space="preserve">
+    <value>Celkový vítěz</value>
+  </data>
+  <data name="Rank" xml:space="preserve">
+    <value>Pořadí</value>
+  </data>
+  <data name="Points" xml:space="preserve">
+    <value>Body</value>
+  </data>
+  <data name="Award Points" xml:space="preserve">
+    <value>Bonusové body</value>
+  </data>
+  <data name="N/A" xml:space="preserve">
+    <value>N/A</value>
+  </data>
+  <data name="Failed to load results: {0}" xml:space="preserve">
+    <value>Nepodařilo se načíst výsledky: {0}</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Země</value>
+  </data>
+  <data name="All countries" xml:space="preserve">
+    <value>Všechny země</value>
+  </data>
+  <data name="Showing only throwers from {0}." xml:space="preserve">
+    <value>Zobrazují se pouze závodníci ze {0}.</value>
+  </data>
+  <data name="No results." xml:space="preserve">
+    <value>Žádné výsledky.</value>
+  </data>
+  <data name="No results for {0}." xml:space="preserve">
+    <value>Žádné výsledky pro {0}.</value>
+  </data>
+  <data name="Thrower" xml:space="preserve">
+    <value>Závodník</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrovat</value>
+  </data>
+  <data name="Registration is full!" xml:space="preserve">
+    <value>Registrace je plná!</value>
+  </data>
+  <data name="Registered throwers" xml:space="preserve">
+    <value>Registrovaní závodníci</value>
+  </data>
+  <data name="Payment done" xml:space="preserve">
+    <value>Platba provedena</value>
+  </data>
+  <data name="Start number" xml:space="preserve">
+    <value>Startovní číslo</value>
+  </data>
+  <data name="Scores List" xml:space="preserve">
+    <value>Seznam výsledků</value>
+  </data>
+  <data name="Bullseyes" xml:space="preserve">
+    <value>Zásahy do středu</value>
+  </data>
+  <data name="Results for {0}" xml:space="preserve">
+    <value>Výsledky pro {0}</value>
+  </data>
+  <data name="Discipline:" xml:space="preserve">
+    <value>Disciplína:</value>
+  </data>
+  <data name="Position:" xml:space="preserve">
+    <value>Pozice:</value>
+  </data>
+  <data name="Points:" xml:space="preserve">
+    <value>Body:</value>
+  </data>
+  <data name="Select disciplines to display" xml:space="preserve">
+    <value>Vyberte disciplíny k zobrazení</value>
+  </data>
+  <data name="Export to PDF" xml:space="preserve">
+    <value>Exportovat do PDF</value>
+  </data>
+  <data name="Overall" xml:space="preserve">
+    <value>Celkově</value>
+  </data>
+  <data name="Overall 2" xml:space="preserve">
+    <value>Celkově 2</value>
+  </data>
+  <data name="Medals by nation" xml:space="preserve">
+    <value>Medaile podle zemí</value>
+  </data>
+  <data name="No medals found." xml:space="preserve">
+    <value>Nebyly nalezeny žádné medaile.</value>
+  </data>
+  <data name="Nation" xml:space="preserve">
+    <value>Země</value>
+  </data>
+  <data name="Gold" xml:space="preserve">
+    <value>Zlato</value>
+  </data>
+  <data name="Silver" xml:space="preserve">
+    <value>Stříbro</value>
+  </data>
+  <data name="Bronze" xml:space="preserve">
+    <value>Bronz</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+    <value>Celkem</value>
+  </data>
+  <data name="Key" xml:space="preserve">
+    <value>Klíč</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Hodnota</value>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>Chyba</value>
+  </data>
+  <data name="Error." xml:space="preserve">
+    <value>Chyba.</value>
+  </data>
+  <data name="An error occurred while processing your request." xml:space="preserve">
+    <value>Při zpracování vašeho požadavku došlo k chybě.</value>
+  </data>
+  <data name="Request ID:" xml:space="preserve">
+    <value>ID požadavku:</value>
+  </data>
+  <data name="Development Mode" xml:space="preserve">
+    <value>Vývojářský režim</value>
+  </data>
+  <data name="Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred." xml:space="preserve">
+    <value><![CDATA[Přepnutí do prostředí <strong>Development</strong> zobrazí podrobné informace o vzniklé chybě.]]></value>
+  </data>
+  <data name="<strong>The Development environment shouldn't be enabled for deployed applications.</strong>" xml:space="preserve">
+    <value><![CDATA[<strong>Prostředí Development by nemělo být povoleno v nasazených aplikacích.</strong>]]></value>
+  </data>
+  <data name="It can result in displaying sensitive information from exceptions to end users." xml:space="preserve">
+    <value>Může vést k zobrazení citlivých informací z výjimek koncovým uživatelům.</value>
+  </data>
+  <data name="For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong> and restarting the app." xml:space="preserve">
+    <value><![CDATA[Pro místní ladění povolte prostředí <strong>Development</strong> nastavením proměnné <strong>ASPNETCORE_ENVIRONMENT</strong> na hodnotu <strong>Development</strong> a restartujte aplikaci.]]></value>
+  </data>
+  <data name="Administration" xml:space="preserve">
+    <value>Administrace</value>
+  </data>
+  <data name="Id" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="User Name" xml:space="preserve">
+    <value>Uživatelské jméno</value>
+  </data>
+  <data name="Action" xml:space="preserve">
+    <value>Akce</value>
+  </data>
+  <data name="Edit User" xml:space="preserve">
+    <value>Upravit uživatele</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Heslo</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Uložit</value>
+  </data>
+  <data name="Add User" xml:space="preserve">
+    <value>Přidat uživatele</value>
+  </data>
+  <data name="You're not signed in as a user in {0}." xml:space="preserve">
+    <value>Nejste přihlášeni jako uživatel v roli {0}.</value>
+  </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.fr.resx
+++ b/CompetitionResults/Resources/SharedResource.fr.resx
@@ -495,4 +495,166 @@
   <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
     <value>Êtes-vous sûr de vouloir supprimer cette discipline ?</value>
   </data>
+  <data name="Total winner" xml:space="preserve">
+    <value>Vainqueur total</value>
+  </data>
+  <data name="Rank" xml:space="preserve">
+    <value>Rang</value>
+  </data>
+  <data name="Points" xml:space="preserve">
+    <value>Points</value>
+  </data>
+  <data name="Award Points" xml:space="preserve">
+    <value>Points bonus</value>
+  </data>
+  <data name="N/A" xml:space="preserve">
+    <value>N/A</value>
+  </data>
+  <data name="Failed to load results: {0}" xml:space="preserve">
+    <value>Échec du chargement des résultats : {0}</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Pays</value>
+  </data>
+  <data name="All countries" xml:space="preserve">
+    <value>Tous les pays</value>
+  </data>
+  <data name="Showing only throwers from {0}." xml:space="preserve">
+    <value>Affichage uniquement des athlètes provenant de {0}.</value>
+  </data>
+  <data name="No results." xml:space="preserve">
+    <value>Aucun résultat.</value>
+  </data>
+  <data name="No results for {0}." xml:space="preserve">
+    <value>Aucun résultat pour {0}.</value>
+  </data>
+  <data name="Thrower" xml:space="preserve">
+    <value>Athlète</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>S'inscrire</value>
+  </data>
+  <data name="Registration is full!" xml:space="preserve">
+    <value>La capacité d'inscription est atteinte !</value>
+  </data>
+  <data name="Registered throwers" xml:space="preserve">
+    <value>Athlètes inscrits</value>
+  </data>
+  <data name="Payment done" xml:space="preserve">
+    <value>Paiement effectué</value>
+  </data>
+  <data name="Start number" xml:space="preserve">
+    <value>Numéro de départ</value>
+  </data>
+  <data name="Scores List" xml:space="preserve">
+    <value>Liste des scores</value>
+  </data>
+  <data name="Bullseyes" xml:space="preserve">
+    <value>Centres</value>
+  </data>
+  <data name="Results for {0}" xml:space="preserve">
+    <value>Résultats pour {0}</value>
+  </data>
+  <data name="Discipline:" xml:space="preserve">
+    <value>Discipline :</value>
+  </data>
+  <data name="Position:" xml:space="preserve">
+    <value>Position :</value>
+  </data>
+  <data name="Points:" xml:space="preserve">
+    <value>Points :</value>
+  </data>
+  <data name="Select disciplines to display" xml:space="preserve">
+    <value>Sélectionnez les disciplines à afficher</value>
+  </data>
+  <data name="Export to PDF" xml:space="preserve">
+    <value>Exporter en PDF</value>
+  </data>
+  <data name="Overall" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="Overall 2" xml:space="preserve">
+    <value>Général 2</value>
+  </data>
+  <data name="Medals by nation" xml:space="preserve">
+    <value>Médailles par nation</value>
+  </data>
+  <data name="No medals found." xml:space="preserve">
+    <value>Aucune médaille trouvée.</value>
+  </data>
+  <data name="Nation" xml:space="preserve">
+    <value>Nation</value>
+  </data>
+  <data name="Gold" xml:space="preserve">
+    <value>Or</value>
+  </data>
+  <data name="Silver" xml:space="preserve">
+    <value>Argent</value>
+  </data>
+  <data name="Bronze" xml:space="preserve">
+    <value>Bronze</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+    <value>Total</value>
+  </data>
+  <data name="Key" xml:space="preserve">
+    <value>Clé</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Valeur</value>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>Erreur</value>
+  </data>
+  <data name="Error." xml:space="preserve">
+    <value>Erreur.</value>
+  </data>
+  <data name="An error occurred while processing your request." xml:space="preserve">
+    <value>Une erreur s'est produite lors du traitement de votre demande.</value>
+  </data>
+  <data name="Request ID:" xml:space="preserve">
+    <value>ID de requête :</value>
+  </data>
+  <data name="Development Mode" xml:space="preserve">
+    <value>Mode développement</value>
+  </data>
+  <data name="Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred." xml:space="preserve">
+    <value><![CDATA[Passer à l'environnement <strong>Development</strong> affiche des informations détaillées sur l'erreur survenue.]]></value>
+  </data>
+  <data name="<strong>The Development environment shouldn't be enabled for deployed applications.</strong>" xml:space="preserve">
+    <value><![CDATA[<strong>L'environnement Development ne doit pas être activé pour les applications déployées.</strong>]]></value>
+  </data>
+  <data name="It can result in displaying sensitive information from exceptions to end users." xml:space="preserve">
+    <value>Cela peut entraîner l'affichage d'informations sensibles issues des exceptions aux utilisateurs finaux.</value>
+  </data>
+  <data name="For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong> and restarting the app." xml:space="preserve">
+    <value><![CDATA[Pour le débogage local, activez l'environnement <strong>Development</strong> en définissant la variable <strong>ASPNETCORE_ENVIRONMENT</strong> sur <strong>Development</strong> puis redémarrez l'application.]]></value>
+  </data>
+  <data name="Administration" xml:space="preserve">
+    <value>Administration</value>
+  </data>
+  <data name="Id" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="User Name" xml:space="preserve">
+    <value>Nom d'utilisateur</value>
+  </data>
+  <data name="Action" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="Edit User" xml:space="preserve">
+    <value>Modifier l'utilisateur</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="Add User" xml:space="preserve">
+    <value>Ajouter un utilisateur</value>
+  </data>
+  <data name="You're not signed in as a user in {0}." xml:space="preserve">
+    <value>Vous n'êtes pas connecté en tant qu'utilisateur dans {0}.</value>
+  </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.it.resx
+++ b/CompetitionResults/Resources/SharedResource.it.resx
@@ -495,4 +495,166 @@
   <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
     <value>Sei sicuro di voler eliminare questa disciplina?</value>
   </data>
+  <data name="Total winner" xml:space="preserve">
+    <value>Vincitore assoluto</value>
+  </data>
+  <data name="Rank" xml:space="preserve">
+    <value>Posizione</value>
+  </data>
+  <data name="Points" xml:space="preserve">
+    <value>Punti</value>
+  </data>
+  <data name="Award Points" xml:space="preserve">
+    <value>Punti bonus</value>
+  </data>
+  <data name="N/A" xml:space="preserve">
+    <value>N/D</value>
+  </data>
+  <data name="Failed to load results: {0}" xml:space="preserve">
+    <value>Impossibile caricare i risultati: {0}</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Paese</value>
+  </data>
+  <data name="All countries" xml:space="preserve">
+    <value>Tutti i paesi</value>
+  </data>
+  <data name="Showing only throwers from {0}." xml:space="preserve">
+    <value>Sono mostrati solo i concorrenti provenienti da {0}.</value>
+  </data>
+  <data name="No results." xml:space="preserve">
+    <value>Nessun risultato.</value>
+  </data>
+  <data name="No results for {0}." xml:space="preserve">
+    <value>Nessun risultato per {0}.</value>
+  </data>
+  <data name="Thrower" xml:space="preserve">
+    <value>Concorrente</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrati</value>
+  </data>
+  <data name="Registration is full!" xml:space="preserve">
+    <value>Le iscrizioni sono al completo!</value>
+  </data>
+  <data name="Registered throwers" xml:space="preserve">
+    <value>Concorrenti registrati</value>
+  </data>
+  <data name="Payment done" xml:space="preserve">
+    <value>Pagamento effettuato</value>
+  </data>
+  <data name="Start number" xml:space="preserve">
+    <value>Numero di partenza</value>
+  </data>
+  <data name="Scores List" xml:space="preserve">
+    <value>Elenco punteggi</value>
+  </data>
+  <data name="Bullseyes" xml:space="preserve">
+    <value>Centri</value>
+  </data>
+  <data name="Results for {0}" xml:space="preserve">
+    <value>Risultati per {0}</value>
+  </data>
+  <data name="Discipline:" xml:space="preserve">
+    <value>Disciplina:</value>
+  </data>
+  <data name="Position:" xml:space="preserve">
+    <value>Posizione:</value>
+  </data>
+  <data name="Points:" xml:space="preserve">
+    <value>Punti:</value>
+  </data>
+  <data name="Select disciplines to display" xml:space="preserve">
+    <value>Seleziona le discipline da visualizzare</value>
+  </data>
+  <data name="Export to PDF" xml:space="preserve">
+    <value>Esporta in PDF</value>
+  </data>
+  <data name="Overall" xml:space="preserve">
+    <value>Classifica generale</value>
+  </data>
+  <data name="Overall 2" xml:space="preserve">
+    <value>Classifica generale 2</value>
+  </data>
+  <data name="Medals by nation" xml:space="preserve">
+    <value>Medaglie per nazione</value>
+  </data>
+  <data name="No medals found." xml:space="preserve">
+    <value>Nessuna medaglia trovata.</value>
+  </data>
+  <data name="Nation" xml:space="preserve">
+    <value>Nazione</value>
+  </data>
+  <data name="Gold" xml:space="preserve">
+    <value>Oro</value>
+  </data>
+  <data name="Silver" xml:space="preserve">
+    <value>Argento</value>
+  </data>
+  <data name="Bronze" xml:space="preserve">
+    <value>Bronzo</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+    <value>Totale</value>
+  </data>
+  <data name="Key" xml:space="preserve">
+    <value>Chiave</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Valore</value>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>Errore</value>
+  </data>
+  <data name="Error." xml:space="preserve">
+    <value>Errore.</value>
+  </data>
+  <data name="An error occurred while processing your request." xml:space="preserve">
+    <value>Si è verificato un errore durante l'elaborazione della richiesta.</value>
+  </data>
+  <data name="Request ID:" xml:space="preserve">
+    <value>ID richiesta:</value>
+  </data>
+  <data name="Development Mode" xml:space="preserve">
+    <value>Modalità sviluppo</value>
+  </data>
+  <data name="Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred." xml:space="preserve">
+    <value><![CDATA[Passare all'ambiente <strong>Development</strong> mostra informazioni dettagliate sull'errore verificatosi.]]></value>
+  </data>
+  <data name="<strong>The Development environment shouldn't be enabled for deployed applications.</strong>" xml:space="preserve">
+    <value><![CDATA[<strong>L'ambiente Development non dovrebbe essere abilitato per le applicazioni distribuite.</strong>]]></value>
+  </data>
+  <data name="It can result in displaying sensitive information from exceptions to end users." xml:space="preserve">
+    <value>Potrebbe esporre agli utenti finali informazioni sensibili provenienti dalle eccezioni.</value>
+  </data>
+  <data name="For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong> and restarting the app." xml:space="preserve">
+    <value><![CDATA[Per il debug locale abilita l'ambiente <strong>Development</strong> impostando la variabile <strong>ASPNETCORE_ENVIRONMENT</strong> su <strong>Development</strong> e riavviando l'applicazione.]]></value>
+  </data>
+  <data name="Administration" xml:space="preserve">
+    <value>Amministrazione</value>
+  </data>
+  <data name="Id" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="User Name" xml:space="preserve">
+    <value>Nome utente</value>
+  </data>
+  <data name="Action" xml:space="preserve">
+    <value>Azione</value>
+  </data>
+  <data name="Edit User" xml:space="preserve">
+    <value>Modifica utente</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Salva</value>
+  </data>
+  <data name="Add User" xml:space="preserve">
+    <value>Aggiungi utente</value>
+  </data>
+  <data name="You're not signed in as a user in {0}." xml:space="preserve">
+    <value>Non sei connesso come utente nel ruolo {0}.</value>
+  </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.ru.resx
+++ b/CompetitionResults/Resources/SharedResource.ru.resx
@@ -495,4 +495,166 @@
   <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
     <value>Вы уверены, что хотите удалить эту дисциплину?</value>
   </data>
+  <data name="Total winner" xml:space="preserve">
+    <value>Общий победитель</value>
+  </data>
+  <data name="Rank" xml:space="preserve">
+    <value>Место</value>
+  </data>
+  <data name="Points" xml:space="preserve">
+    <value>Очки</value>
+  </data>
+  <data name="Award Points" xml:space="preserve">
+    <value>Бонусные очки</value>
+  </data>
+  <data name="N/A" xml:space="preserve">
+    <value>Н/Д</value>
+  </data>
+  <data name="Failed to load results: {0}" xml:space="preserve">
+    <value>Не удалось загрузить результаты: {0}</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Страна</value>
+  </data>
+  <data name="All countries" xml:space="preserve">
+    <value>Все страны</value>
+  </data>
+  <data name="Showing only throwers from {0}." xml:space="preserve">
+    <value>Показаны только участники из {0}.</value>
+  </data>
+  <data name="No results." xml:space="preserve">
+    <value>Нет результатов.</value>
+  </data>
+  <data name="No results for {0}." xml:space="preserve">
+    <value>Нет результатов для {0}.</value>
+  </data>
+  <data name="Thrower" xml:space="preserve">
+    <value>Участник</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Зарегистрироваться</value>
+  </data>
+  <data name="Registration is full!" xml:space="preserve">
+    <value>Регистрация заполнена!</value>
+  </data>
+  <data name="Registered throwers" xml:space="preserve">
+    <value>Зарегистрированные участники</value>
+  </data>
+  <data name="Payment done" xml:space="preserve">
+    <value>Оплата выполнена</value>
+  </data>
+  <data name="Start number" xml:space="preserve">
+    <value>Стартовый номер</value>
+  </data>
+  <data name="Scores List" xml:space="preserve">
+    <value>Список очков</value>
+  </data>
+  <data name="Bullseyes" xml:space="preserve">
+    <value>Буллзай</value>
+  </data>
+  <data name="Results for {0}" xml:space="preserve">
+    <value>Результаты для {0}</value>
+  </data>
+  <data name="Discipline:" xml:space="preserve">
+    <value>Дисциплина:</value>
+  </data>
+  <data name="Position:" xml:space="preserve">
+    <value>Позиция:</value>
+  </data>
+  <data name="Points:" xml:space="preserve">
+    <value>Очки:</value>
+  </data>
+  <data name="Select disciplines to display" xml:space="preserve">
+    <value>Выберите дисциплины для отображения</value>
+  </data>
+  <data name="Export to PDF" xml:space="preserve">
+    <value>Экспорт в PDF</value>
+  </data>
+  <data name="Overall" xml:space="preserve">
+    <value>Общий итог</value>
+  </data>
+  <data name="Overall 2" xml:space="preserve">
+    <value>Общий итог 2</value>
+  </data>
+  <data name="Medals by nation" xml:space="preserve">
+    <value>Медали по странам</value>
+  </data>
+  <data name="No medals found." xml:space="preserve">
+    <value>Медалей не найдено.</value>
+  </data>
+  <data name="Nation" xml:space="preserve">
+    <value>Страна</value>
+  </data>
+  <data name="Gold" xml:space="preserve">
+    <value>Золото</value>
+  </data>
+  <data name="Silver" xml:space="preserve">
+    <value>Серебро</value>
+  </data>
+  <data name="Bronze" xml:space="preserve">
+    <value>Бронза</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+    <value>Итого</value>
+  </data>
+  <data name="Key" xml:space="preserve">
+    <value>Ключ</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Значение</value>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>Ошибка</value>
+  </data>
+  <data name="Error." xml:space="preserve">
+    <value>Ошибка.</value>
+  </data>
+  <data name="An error occurred while processing your request." xml:space="preserve">
+    <value>При обработке вашего запроса произошла ошибка.</value>
+  </data>
+  <data name="Request ID:" xml:space="preserve">
+    <value>Идентификатор запроса:</value>
+  </data>
+  <data name="Development Mode" xml:space="preserve">
+    <value>Режим разработки</value>
+  </data>
+  <data name="Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred." xml:space="preserve">
+    <value><![CDATA[Переход в среду <strong>Development</strong> показывает подробную информацию о возникшей ошибке.]]></value>
+  </data>
+  <data name="<strong>The Development environment shouldn't be enabled for deployed applications.</strong>" xml:space="preserve">
+    <value><![CDATA[<strong>Среду Development не следует включать для развернутых приложений.</strong>]]></value>
+  </data>
+  <data name="It can result in displaying sensitive information from exceptions to end users." xml:space="preserve">
+    <value>Это может привести к отображению конфиденциальной информации из исключений конечным пользователям.</value>
+  </data>
+  <data name="For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong> and restarting the app." xml:space="preserve">
+    <value><![CDATA[Для локальной отладки включите среду <strong>Development</strong>, установив переменную <strong>ASPNETCORE_ENVIRONMENT</strong> в значение <strong>Development</strong> и перезапустив приложение.]]></value>
+  </data>
+  <data name="Administration" xml:space="preserve">
+    <value>Администрирование</value>
+  </data>
+  <data name="Id" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="User Name" xml:space="preserve">
+    <value>Имя пользователя</value>
+  </data>
+  <data name="Action" xml:space="preserve">
+    <value>Действие</value>
+  </data>
+  <data name="Edit User" xml:space="preserve">
+    <value>Редактировать пользователя</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="Add User" xml:space="preserve">
+    <value>Добавить пользователя</value>
+  </data>
+  <data name="You're not signed in as a user in {0}." xml:space="preserve">
+    <value>Вы не вошли как пользователь в роли {0}.</value>
+  </data>
 </root>

--- a/CompetitionResults/Resources/SharedResource.sk.resx
+++ b/CompetitionResults/Resources/SharedResource.sk.resx
@@ -495,4 +495,166 @@
   <data name="Are you sure you want to delete this discipline?" xml:space="preserve">
     <value>Naozaj chcete odstrániť túto disciplínu?</value>
   </data>
+  <data name="Total winner" xml:space="preserve">
+    <value>Celkový víťaz</value>
+  </data>
+  <data name="Rank" xml:space="preserve">
+    <value>Poradie</value>
+  </data>
+  <data name="Points" xml:space="preserve">
+    <value>Body</value>
+  </data>
+  <data name="Award Points" xml:space="preserve">
+    <value>Bonusové body</value>
+  </data>
+  <data name="N/A" xml:space="preserve">
+    <value>N/A</value>
+  </data>
+  <data name="Failed to load results: {0}" xml:space="preserve">
+    <value>Nepodarilo sa načítať výsledky: {0}</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Krajina</value>
+  </data>
+  <data name="All countries" xml:space="preserve">
+    <value>Všetky krajiny</value>
+  </data>
+  <data name="Showing only throwers from {0}." xml:space="preserve">
+    <value>Zobrazujú sa iba súťažiaci z {0}.</value>
+  </data>
+  <data name="No results." xml:space="preserve">
+    <value>Žiadne výsledky.</value>
+  </data>
+  <data name="No results for {0}." xml:space="preserve">
+    <value>Žiadne výsledky pre {0}.</value>
+  </data>
+  <data name="Thrower" xml:space="preserve">
+    <value>Súťažiaci</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrovať</value>
+  </data>
+  <data name="Registration is full!" xml:space="preserve">
+    <value>Registrácia je plná!</value>
+  </data>
+  <data name="Registered throwers" xml:space="preserve">
+    <value>Registrovaní súťažiaci</value>
+  </data>
+  <data name="Payment done" xml:space="preserve">
+    <value>Platba vykonaná</value>
+  </data>
+  <data name="Start number" xml:space="preserve">
+    <value>Štartovné číslo</value>
+  </data>
+  <data name="Scores List" xml:space="preserve">
+    <value>Zoznam bodov</value>
+  </data>
+  <data name="Bullseyes" xml:space="preserve">
+    <value>Zásahy do stredu</value>
+  </data>
+  <data name="Results for {0}" xml:space="preserve">
+    <value>Výsledky pre {0}</value>
+  </data>
+  <data name="Discipline:" xml:space="preserve">
+    <value>Disciplína:</value>
+  </data>
+  <data name="Position:" xml:space="preserve">
+    <value>Pozícia:</value>
+  </data>
+  <data name="Points:" xml:space="preserve">
+    <value>Body:</value>
+  </data>
+  <data name="Select disciplines to display" xml:space="preserve">
+    <value>Vyberte disciplíny na zobrazenie</value>
+  </data>
+  <data name="Export to PDF" xml:space="preserve">
+    <value>Exportovať do PDF</value>
+  </data>
+  <data name="Overall" xml:space="preserve">
+    <value>Celkové poradie</value>
+  </data>
+  <data name="Overall 2" xml:space="preserve">
+    <value>Celkové poradie 2</value>
+  </data>
+  <data name="Medals by nation" xml:space="preserve">
+    <value>Medaily podľa krajín</value>
+  </data>
+  <data name="No medals found." xml:space="preserve">
+    <value>Nenašli sa žiadne medaily.</value>
+  </data>
+  <data name="Nation" xml:space="preserve">
+    <value>Krajina</value>
+  </data>
+  <data name="Gold" xml:space="preserve">
+    <value>Zlato</value>
+  </data>
+  <data name="Silver" xml:space="preserve">
+    <value>Striebro</value>
+  </data>
+  <data name="Bronze" xml:space="preserve">
+    <value>Bronz</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+    <value>Spolu</value>
+  </data>
+  <data name="Key" xml:space="preserve">
+    <value>Kľúč</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Hodnota</value>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>Chyba</value>
+  </data>
+  <data name="Error." xml:space="preserve">
+    <value>Chyba.</value>
+  </data>
+  <data name="An error occurred while processing your request." xml:space="preserve">
+    <value>Pri spracovaní vašej požiadavky nastala chyba.</value>
+  </data>
+  <data name="Request ID:" xml:space="preserve">
+    <value>ID požiadavky:</value>
+  </data>
+  <data name="Development Mode" xml:space="preserve">
+    <value>Režim vývoja</value>
+  </data>
+  <data name="Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred." xml:space="preserve">
+    <value><![CDATA[Prechod do prostredia <strong>Development</strong> zobrazí podrobné informácie o vzniknutej chybe.]]></value>
+  </data>
+  <data name="<strong>The Development environment shouldn't be enabled for deployed applications.</strong>" xml:space="preserve">
+    <value><![CDATA[<strong>Prostredie Development by sa nemalo používať v nasadených aplikáciách.</strong>]]></value>
+  </data>
+  <data name="It can result in displaying sensitive information from exceptions to end users." xml:space="preserve">
+    <value>Môže to viesť k zobrazeniu citlivých informácií z výnimiek koncovým používateľom.</value>
+  </data>
+  <data name="For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong> and restarting the app." xml:space="preserve">
+    <value><![CDATA[Na lokálne ladenie povoľte prostredie <strong>Development</strong> nastavením premennej <strong>ASPNETCORE_ENVIRONMENT</strong> na <strong>Development</strong> a reštartujte aplikáciu.]]></value>
+  </data>
+  <data name="Administration" xml:space="preserve">
+    <value>Administrácia</value>
+  </data>
+  <data name="Id" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="User Name" xml:space="preserve">
+    <value>Používateľské meno</value>
+  </data>
+  <data name="Action" xml:space="preserve">
+    <value>Akcia</value>
+  </data>
+  <data name="Edit User" xml:space="preserve">
+    <value>Upraviť používateľa</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Heslo</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Uložiť</value>
+  </data>
+  <data name="Add User" xml:space="preserve">
+    <value>Pridať používateľa</value>
+  </data>
+  <data name="You're not signed in as a user in {0}." xml:space="preserve">
+    <value>Nie ste prihlásení ako používateľ v roli {0}.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- replace hard-coded text in results, registration, administration, and error Razor pages with shared resource lookups
- update all shared language resource files with translations for the new localization keys

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe04e2b1c832c9a1528c89bb4fa3d