### PR TITLE
Replace browser dialogs with reusable confirmation modal

### DIFF
--- a/CompetitionResults/Components/Pages/CategoriesList.razor
+++ b/CompetitionResults/Components/Pages/CategoriesList.razor
@@ -4,7 +4,6 @@
 @inject CategoryService CategoryService
 @inject CompetitionStateService CompetitionState
 @implements IDisposable
-@inject IJSRuntime JSRuntime
 @inject IStringLocalizer<SharedResource> L
 
 <h3>@L["Categories List"]</h3>
@@ -14,6 +13,7 @@
 <button @onclick="AddNew">@L["Add New Category"]</button>
 
 <CategoryEditModal @ref="categoryEditModal" OnClose="HandleModalClose" Category="currentCategory" OnFormSubmit="HandleFormSubmit" />
+<ConfirmationDialog @ref="confirmationDialog" />
 
 @if (categories == null)
 {
@@ -86,21 +86,35 @@ else
 
     private async Task DeleteCategory(int categoryId)
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to delete this category?"].Value);
+        if (confirmationDialog is null)
+        {
+            return;
+        }
+
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Are you sure you want to delete this category?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
+
         if (confirmed)
         {
             await CategoryService.DeleteCategoryAsync(categoryId);
             LoadData();
-        }        
+        }
     }
 
-    private async Task HandleFormSubmit()
+    private Task HandleFormSubmit()
     {
         LoadData();
+        return Task.CompletedTask;
     }
 
-    private async Task HandleModalClose()
+    private Task HandleModalClose()
     {
         LoadData();
+        return Task.CompletedTask;
     }
+
+    private ConfirmationDialog? confirmationDialog;
 }

--- a/CompetitionResults/Components/Pages/CompetitionsList.razor
+++ b/CompetitionResults/Components/Pages/CompetitionsList.razor
@@ -4,7 +4,6 @@
 @using System.Security.Claims
 @inject CompetitionService CompetitionService
 @inject UserIdStateService UserIdStateService
-@inject IJSRuntime JSRuntime
 @inject IStringLocalizer<SharedResource> L
 
 <h3>@L["Competitions List"]</h3>
@@ -13,6 +12,7 @@
         <button @onclick="AddNew">@L["Add New Competition"]</button>
 
         <CompetitionEditModal @ref="competitionEditModal" OnClose="HandleModalClose" Category="currentCompetition" OnFormSubmit="HandleFormSubmit" />
+        <ConfirmationDialog @ref="confirmationDialog" />
 
         @if (competitions == null)
         {
@@ -99,7 +99,17 @@
 
     private async Task DeleteCompetition(int competitionId)
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to delete this competition?"].Value);
+        if (confirmationDialog is null)
+        {
+            return;
+        }
+
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Are you sure you want to delete this competition?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
+
         if (confirmed)
         {
             await CompetitionService.DeleteCompetitionAsync(competitionId);
@@ -118,4 +128,6 @@
         LoadData();
         return Task.CompletedTask;
     }
+
+    private ConfirmationDialog? confirmationDialog;
 }

--- a/CompetitionResults/Components/Pages/DisciplinesList.razor
+++ b/CompetitionResults/Components/Pages/DisciplinesList.razor
@@ -4,7 +4,6 @@
 @inject DisciplineService DisciplineService
 @inject CompetitionStateService CompetitionState
 @implements IDisposable
-@inject IJSRuntime JSRuntime
 @inject IStringLocalizer<SharedResource> L
 
 <h3>@L["Disciplines List"]</h3>
@@ -14,6 +13,7 @@
 <button @onclick="AddNew">@L["Add New Discipline"]</button>
 
 <DisciplineEditModal @ref="disciplineEditModal" OnClose="HandleModalClose" Discipline="currentDiscipline" OnFormSubmit="HandleFormSubmit" />
+<ConfirmationDialog @ref="confirmationDialog" />
 
 @if (disciplines == null)
 {
@@ -93,21 +93,35 @@ else
 
     private async Task DeleteDiscipline(int disciplineId)
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to delete this discipline?"].Value);
+        if (confirmationDialog is null)
+        {
+            return;
+        }
+
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Are you sure you want to delete this discipline?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
+
         if (confirmed)
         {
             await DisciplineService.DeleteDisciplineAsync(disciplineId);
             LoadData();
-        }        
+        }
     }
 
-    private async Task HandleFormSubmit()
+    private Task HandleFormSubmit()
     {
         LoadData();
+        return Task.CompletedTask;
     }
 
-    private async Task HandleModalClose()
+    private Task HandleModalClose()
     {
         LoadData();
+        return Task.CompletedTask;
     }
+
+    private ConfirmationDialog? confirmationDialog;
 }

--- a/CompetitionResults/Components/Pages/Index.razor
+++ b/CompetitionResults/Components/Pages/Index.razor
@@ -1,6 +1,7 @@
 @page "/"
 @using System.Security.Claims
 @using CompetitionResults.Data
+@using CompetitionResults.Components.Shared
 @inject CompetitionService CompetitionService
 @inject CompetitionStateService CompetitionState
 @inject ResultService ResultsServiceInstance
@@ -12,6 +13,8 @@
 <h1>@L["Competition Scores"]</h1>
 
 <p>@L["App to make competition scoring easy and fast."]</p>
+
+<ConfirmationDialog @ref="confirmationDialog" />
 
 <AuthorizeView Roles="Admin">
     <Authorized>
@@ -60,7 +63,17 @@
 
     private async void ClearScores()
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to clear all results?"].Value);
+        if (confirmationDialog is null)
+        {
+            return;
+        }
+
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Are you sure you want to clear all results?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
+
         if (confirmed)
         {
             await ResultsServiceInstance.DeleteResultsAsync(CompetitionState.SelectedCompetitionId);
@@ -69,7 +82,17 @@
 
     private async void FillRandomScores()
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Generate random scores for all disciplines and throwers?"].Value);
+        if (confirmationDialog is null)
+        {
+            return;
+        }
+
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Generate random scores for all disciplines and throwers?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
+
         if (confirmed)
         {
             await ResultsServiceInstance.FillRandomScoresAsync(CompetitionState.SelectedCompetitionId);
@@ -78,7 +101,17 @@
 
     private async void ClearDatabase()
     {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to clear database?"].Value);
+        if (confirmationDialog is null)
+        {
+            return;
+        }
+
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Are you sure you want to clear database?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
+
         if (confirmed)
         {
             await CompetitionService.ClearDBAsync();
@@ -135,4 +168,6 @@
             await CompetitionService.RestoreCompetitionAsync(jsonData);
         }
     }
+
+    private ConfirmationDialog? confirmationDialog;
 }

--- a/CompetitionResults/Components/Pages/ThrowersList.razor
+++ b/CompetitionResults/Components/Pages/ThrowersList.razor
@@ -23,6 +23,8 @@
 
                 <ThrowerEditModal @ref="throwerEditModal" OnClose="HandleModalClose" Thrower="selectedThrower" OnFormSubmit="HandleFormSubmit" />
 
+                <ConfirmationDialog @ref="confirmationDialog" />
+
                 @if (throwers == null)
                 {
                         <p><em>@L["Loading..."]</em></p>
@@ -157,6 +159,7 @@
 @code {
         private ThrowerEditModal throwerEditModal;
         private GeneralEmailModal generalEmailModal;
+        private ConfirmationDialog? confirmationDialog;
         private List<Thrower> throwers;
         private Thrower selectedThrower = new Thrower();
 
@@ -251,73 +254,137 @@
 
 	private async Task SendEmail(Thrower thrower)
 	{
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to send registration email to this thrower?"].Value);
-		if (confirmed)
-		{
-			await ThrowerService.ResendEmailAsync(thrower);
-		}
+        if (confirmationDialog is null)
+        {
+            return;
+        }
+
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Are you sure you want to send registration email to this thrower?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
+
+        if (confirmed)
+        {
+                await ThrowerService.ResendEmailAsync(thrower);
+        }
 	}
 
         private async Task SendUnpaidEmail(Thrower thrower)
         {
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to send unpaid email to this thrower?"].Value);
-            if (confirmed)
-            {
-                await ThrowerService.SendUnpaidEmail(thrower);
-            }
+        if (confirmationDialog is null)
+        {
+            return;
         }
 
-	private async Task SendEmailsToUnpaid()
-	{
-		var unpaidThrowers = throwers.Where(t => !t.PaymentDone).ToList();
-		if (unpaidThrowers.Any())
-		{
-            var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to send emails to {0} unpaid throwers?", unpaidThrowers.Count].Value);
-			if (confirmed)
-			{
-                                foreach (var thrower in unpaidThrowers)
-                                {
-                                        await ThrowerService.SendUnpaidEmail(thrower);
-                                }
-                await JSRuntime.InvokeVoidAsync("alert", L["Emails sent to unpaid throwers."].Value);
-			}
-		}
-		else
-		{
-            await JSRuntime.InvokeVoidAsync("alert", L["No unpaid throwers to send emails to."].Value);
-		}
-	}
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Are you sure you want to send unpaid email to this thrower?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
 
-        private async Task SendEmails(string localMessage, string englishMessage)
+        if (confirmed)
         {
-                var allThrowers = throwers.ToList();
-                if (allThrowers.Any())
+            await ThrowerService.SendUnpaidEmail(thrower);
+        }
+        }
+
+        private async Task SendEmailsToUnpaid()
+        {
+                if (confirmationDialog is null)
                 {
-            var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to send emails to {0} throwers?", allThrowers.Count].Value);
-                        if (confirmed)
-                        {
-                                foreach (var thrower in allThrowers)
-                                {
-                                        ThrowerService.SendGeneralEmail(thrower, localMessage, englishMessage);
-                                }
-                await JSRuntime.InvokeVoidAsync("alert", L["Emails sent to throwers."].Value);
-                        }
+                        return;
+                }
+
+                var unpaidThrowers = throwers.Where(t => !t.PaymentDone).ToList();
+                if (unpaidThrowers.Any())
+                {
+            var confirmed = await confirmationDialog.ShowAsync(
+                L["Confirmation"].Value,
+                L["Are you sure you want to send emails to {0} unpaid throwers?", unpaidThrowers.Count].Value,
+                L["Yes"].Value,
+                L["Cancel"].Value);
+
+            if (confirmed)
+            {
+                foreach (var thrower in unpaidThrowers)
+                {
+                        await ThrowerService.SendUnpaidEmail(thrower);
+                }
+
+                await confirmationDialog.ShowAsync(
+                    L["Information"].Value,
+                    L["Emails sent to unpaid throwers."].Value,
+                    L["OK"].Value);
+            }
                 }
                 else
                 {
-            await JSRuntime.InvokeVoidAsync("alert", L["No throwers to send emails to."].Value);
+            await confirmationDialog.ShowAsync(
+                L["Information"].Value,
+                L["No unpaid throwers to send emails to."].Value,
+                L["OK"].Value);
                 }
         }
 
-	private async Task DeleteThrower(int id)
-	{
-        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", L["Are you sure you want to delete this thrower?"].Value);
-		if (confirmed)
-		{
-			await ThrowerService.DeleteThrowerAsync(id);
-			LoadData();
-		}
-	}
+        private async Task SendEmails(string localMessage, string englishMessage)
+        {
+                if (confirmationDialog is null)
+                {
+                        return;
+                }
+
+                var allThrowers = throwers.ToList();
+                if (allThrowers.Any())
+                {
+            var confirmed = await confirmationDialog.ShowAsync(
+                L["Confirmation"].Value,
+                L["Are you sure you want to send emails to {0} throwers?", allThrowers.Count].Value,
+                L["Yes"].Value,
+                L["Cancel"].Value);
+
+            if (confirmed)
+            {
+                foreach (var thrower in allThrowers)
+                {
+                        ThrowerService.SendGeneralEmail(thrower, localMessage, englishMessage);
+                }
+
+                await confirmationDialog.ShowAsync(
+                    L["Information"].Value,
+                    L["Emails sent to throwers."].Value,
+                    L["OK"].Value);
+            }
+                }
+                else
+                {
+            await confirmationDialog.ShowAsync(
+                L["Information"].Value,
+                L["No throwers to send emails to."].Value,
+                L["OK"].Value);
+                }
+        }
+
+        private async Task DeleteThrower(int id)
+        {
+        if (confirmationDialog is null)
+        {
+            return;
+        }
+
+        var confirmed = await confirmationDialog.ShowAsync(
+            L["Confirmation"].Value,
+            L["Are you sure you want to delete this thrower?"].Value,
+            L["Yes"].Value,
+            L["Cancel"].Value);
+
+        if (confirmed)
+        {
+                await ThrowerService.DeleteThrowerAsync(id);
+                LoadData();
+        }
+        }
 
         private decimal CalculateTargetPayment(Thrower thrower)
         {

--- a/CompetitionResults/Components/Shared/ConfirmationDialog.razor
+++ b/CompetitionResults/Components/Shared/ConfirmationDialog.razor
@@ -1,0 +1,71 @@
+@inject IStringLocalizer<SharedResource> L
+
+@if (IsOpen)
+{
+    <div class="modal fade show" style="display:block;" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">@Title</h5>
+                    <button type="button" class="btn-close" @onclick="Cancel"></button>
+                </div>
+                <div class="modal-body">
+                    <p>@Message</p>
+                </div>
+                <div class="modal-footer">
+                    @if (ShowCancelButton)
+                    {
+                        <button type="button" class="btn btn-secondary" @onclick="Cancel">@CancelText</button>
+                    }
+                    <button type="button" class="btn btn-primary" @onclick="Confirm">@ConfirmText</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal-backdrop fade show"></div>
+}
+
+@code {
+    private TaskCompletionSource<bool>? _completionSource;
+
+    private bool IsOpen { get; set; }
+    private string Title { get; set; } = string.Empty;
+    private string Message { get; set; } = string.Empty;
+    private string ConfirmText { get; set; } = string.Empty;
+    private string CancelText { get; set; } = string.Empty;
+    private bool ShowCancelButton { get; set; }
+
+    public Task<bool> ShowAsync(string title, string message, string? confirmText = null, string? cancelText = null)
+    {
+        Title = title;
+        Message = message;
+        ConfirmText = string.IsNullOrWhiteSpace(confirmText) ? L["OK"].Value : confirmText;
+        CancelText = string.IsNullOrWhiteSpace(cancelText) ? L["Cancel"].Value : cancelText;
+        ShowCancelButton = !string.IsNullOrWhiteSpace(cancelText);
+
+        _completionSource = new TaskCompletionSource<bool>();
+        IsOpen = true;
+        _ = InvokeAsync(StateHasChanged);
+
+        return _completionSource.Task;
+    }
+
+    private Task Confirm()
+    {
+        return CloseAsync(true);
+    }
+
+    private Task Cancel()
+    {
+        return CloseAsync(false);
+    }
+
+    private Task CloseAsync(bool result)
+    {
+        IsOpen = false;
+        _ = InvokeAsync(StateHasChanged);
+        _completionSource?.TrySetResult(result);
+        _completionSource = null;
+        return Task.CompletedTask;
+    }
+}

--- a/CompetitionResults/Resources/SharedResource.cs.resx
+++ b/CompetitionResults/Resources/SharedResource.cs.resx
@@ -348,6 +348,15 @@
   <data name="English message:" xml:space="preserve">
     <value>Zpráva v angličtině:</value>
   </data>
+  <data name="Confirmation" xml:space="preserve">
+    <value>Potvrzení</value>
+  </data>
+  <data name="Information" xml:space="preserve">
+    <value>Informace</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>Zrušit</value>
   </data>

--- a/CompetitionResults/Resources/SharedResource.fr.resx
+++ b/CompetitionResults/Resources/SharedResource.fr.resx
@@ -348,6 +348,15 @@
   <data name="English message:" xml:space="preserve">
     <value>Message en anglais :</value>
   </data>
+  <data name="Confirmation" xml:space="preserve">
+    <value>Confirmation</value>
+  </data>
+  <data name="Information" xml:space="preserve">
+    <value>Information</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>Annuler</value>
   </data>

--- a/CompetitionResults/Resources/SharedResource.it.resx
+++ b/CompetitionResults/Resources/SharedResource.it.resx
@@ -348,6 +348,15 @@
   <data name="English message:" xml:space="preserve">
     <value>Messaggio in inglese:</value>
   </data>
+  <data name="Confirmation" xml:space="preserve">
+    <value>Conferma</value>
+  </data>
+  <data name="Information" xml:space="preserve">
+    <value>Informazioni</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>Annulla</value>
   </data>

--- a/CompetitionResults/Resources/SharedResource.ru.resx
+++ b/CompetitionResults/Resources/SharedResource.ru.resx
@@ -348,6 +348,15 @@
   <data name="English message:" xml:space="preserve">
     <value>Сообщение на английском:</value>
   </data>
+  <data name="Confirmation" xml:space="preserve">
+    <value>Подтверждение</value>
+  </data>
+  <data name="Information" xml:space="preserve">
+    <value>Информация</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>ОК</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>Отмена</value>
   </data>

--- a/CompetitionResults/Resources/SharedResource.sk.resx
+++ b/CompetitionResults/Resources/SharedResource.sk.resx
@@ -348,6 +348,15 @@
   <data name="English message:" xml:space="preserve">
     <value>Správa v angličtine:</value>
   </data>
+  <data name="Confirmation" xml:space="preserve">
+    <value>Potvrdenie</value>
+  </data>
+  <data name="Information" xml:space="preserve">
+    <value>Informácia</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>Zrušiť</value>
   </data>


### PR DESCRIPTION
## Summary
- add a reusable `ConfirmationDialog` component that renders a Bootstrap-styled modal for confirmations and alerts
- refactor admin and management pages to use the shared dialog instead of `window.confirm`/`alert`
- add localized resources for the dialog text in each supported language

## Testing
- dotnet test *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dca98b52e0832c8ff47519a0b68a68