### PR TITLE
Preselect first available competition on registration

### DIFF
--- a/CompetitionResults/Components/Pages/Registration.razor
+++ b/CompetitionResults/Components/Pages/Registration.razor
@@ -139,10 +139,13 @@ else
         {
             CompetitionState.SelectedCompetitionId = CompetitionId.Value;
         }
-        else if (competitions != null && competitions.Count > 0 && CompetitionState.SelectedCompetitionId == 0)
+        else if (CompetitionState.SelectedCompetitionId == 0)
         {
-            // Automatically select the first competition if no valid CompetitionId is provided
-            CompetitionState.SelectedCompetitionId = competitions[0].Id;
+            var defaultCompetitionId = await GetFirstAvailableCompetitionIdAsync();
+            if (defaultCompetitionId != 0)
+            {
+                CompetitionState.SelectedCompetitionId = defaultCompetitionId;
+            }
         }
 
         LoadData();
@@ -151,10 +154,13 @@ else
     private async void LoadData()
     {
         competitions = await CompetitionService.GetAllCompetitionsAsync();
-        if (competitions != null && competitions.Count > 0 && CompetitionState.SelectedCompetitionId == 0)
+        if (CompetitionState.SelectedCompetitionId == 0)
         {
-            // Automatically select the first competition
-            CompetitionState.SelectedCompetitionId = competitions[0].Id;
+            var defaultCompetitionId = await GetFirstAvailableCompetitionIdAsync();
+            if (defaultCompetitionId != 0)
+            {
+                CompetitionState.SelectedCompetitionId = defaultCompetitionId;
+            }
         }
 
         var categories = await CategoryService.GetAllCategoriesAsync(CompetitionState.SelectedCompetitionId);
@@ -182,6 +188,30 @@ else
         .ToDictionary(g => g.Key, g => g.Count());
 
         StateHasChanged();
+    }
+
+    private async Task<int> GetFirstAvailableCompetitionIdAsync()
+    {
+        if (competitions == null || competitions.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var competition in competitions)
+        {
+            if (!competition.MaxCompetitorCount.HasValue)
+            {
+                continue;
+            }
+
+            var throwerCount = await ThrowerService.GetThrowerCountAsync(competition.Id);
+            if (competition.MaxCompetitorCount.Value > throwerCount)
+            {
+                return competition.Id;
+            }
+        }
+
+        return competitions[0].Id;
     }
 
     private bool IsSelected(int competitionId)

--- a/CompetitionResults/Data/ThrowerService.cs
+++ b/CompetitionResults/Data/ThrowerService.cs
@@ -35,6 +35,13 @@ namespace CompetitionResults.Data
                 .ToListAsync();
         }
 
+        public async Task<int> GetThrowerCountAsync(int competitionId)
+        {
+            return await _context.Throwers
+                .Where(t => t.CompetitionId == competitionId)
+                .CountAsync();
+        }
+
         public async Task<Thrower> GetThrowerByIdAsync(int id)
         {
             return await _context.Throwers.FindAsync(id);


### PR DESCRIPTION
## Summary
- add a helper in the thrower service to count registered competitors per competition
- default the registration page selection to the first competition that still has capacity

## Testing
- dotnet test *(fails: `dotnet` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dceb242e60832cb1bd4e97914c4ff6