### PR TITLE
Redirect to home after selecting competition

### DIFF
--- a/CompetitionResults/Components/Shared/CompetitionDropdown.razor
+++ b/CompetitionResults/Components/Shared/CompetitionDropdown.razor
@@ -1,8 +1,10 @@
 @using CompetitionResults.Data
+@using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.JSInterop
 @using System.Globalization
 @using System.Security.Claims
+@inject NavigationManager NavigationManager
 @inject CompetitionStateService CompetitionState
 @inject CompetitionService CompetitionService
 @inject UserIdStateService UserIdStateService
@@ -89,6 +91,7 @@
             persistedCompetitionId = competitionId;
             errorMessage = string.Empty;
             await PersistSelectionAsync(competitionId);
+            NavigationManager.NavigateTo("/", forceLoad: true);
         }
         else
         {


### PR DESCRIPTION
## Summary
- inject the NavigationManager into the competition dropdown component
- trigger a redirect to the home page whenever a competition selection is made so the data reloads

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcfc945bb4832c8db2e5de655a6ffe