### PR TITLE
Add pinch-to-zoom support for results pages

### DIFF
--- a/CompetitionResults/Components/App.razor
+++ b/CompetitionResults/Components/App.razor
@@ -14,6 +14,9 @@
     <link rel="icon" type="image/png" href="favicon.png" />
 
     <!-- Custom scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@panzoom/panzoom@4.6.0/dist/panzoom.min.js"
+            integrity="sha384-p/V9q47QHNmBI0EG7lJPLVHC5WN1mgpLtNpFykf0IX8iJ4xDCYPWEXcigFOvYW52"
+            crossorigin="anonymous"></script>
     <script src="js/site.js"></script>
 
     <link rel="stylesheet" href="@Assets["css/site.css"]" />

--- a/CompetitionResults/Components/Pages/Results.razor
+++ b/CompetitionResults/Components/Pages/Results.razor
@@ -38,14 +38,15 @@
 			</div>
 
 			<div class="container m-0 p-0 small-font row">
-				<div class="col-12" id="resultsOfGame">
-					@if (selectedDisciplineId != 0 || selectedCategoryId != 0)
-					{
-						<h3 class="mb-1 p-0">
-							@categories.FirstOrDefault(c => c.Id == selectedCategoryId)?.Name @(disciplines.Where(d => d.Id == selectedDisciplineId).FirstOrDefault().Name)
-						</h3>
-						<div class="d-flex flex-wrap">
-							@for (int i = 0; i < (selectedCategoryId != 0 ? MaxResultsCount(selectedCategoryId) : MaxResultsCount()); i++)
+                                <div class="col-12" id="resultsOfGame">
+                                        <PinchZoomContainer MaxScale="10">
+                                                @if (selectedDisciplineId != 0 || selectedCategoryId != 0)
+                                                {
+                                                        <h3 class="mb-1 p-0">
+                                                                @categories.FirstOrDefault(c => c.Id == selectedCategoryId)?.Name @(disciplines.Where(d => d.Id == selectedDisciplineId).FirstOrDefault().Name)
+                                                        </h3>
+                                                        <div class="d-flex flex-wrap">
+                                                                @for (int i = 0; i < (selectedCategoryId != 0 ? MaxResultsCount(selectedCategoryId) : MaxResultsCount()); i++)
 							{
 								var throwerName = selectedCategoryId != 0 ? GetResultNameForDiscipline(selectedCategoryId, selectedDisciplineId, i) : GetResultNameForDisciplineOverall(selectedDisciplineId, i);
 								var points = selectedCategoryId != 0 ? GetResultValueForDiscipline(selectedCategoryId, selectedDisciplineId, i) : GetResultValueForDisciplineOverall(selectedDisciplineId, i);
@@ -85,14 +86,14 @@
                                                                         </div>
                                                                         <div class="award-points">@L["Award Points"]: @awardPoints</div>
 								</div>
-							}
-						</div>
-					}
-					else if (MaxResultsCount() > 0)
-					{
-                                                <h3 class="mb-1 p-0">@L["Total winner"]</h3>
-						<div class="d-flex flex-wrap">
-							@for (int i = 0; i < MaxResultsCount(); i++)
+                                                        }
+                                                </div>
+                                                }
+                                                else if (MaxResultsCount() > 0)
+                                                {
+                                                        <h3 class="mb-1 p-0">@L["Total winner"]</h3>
+                                                        <div class="d-flex flex-wrap">
+                                                                @for (int i = 0; i < MaxResultsCount(); i++)
 							{
 								var throwerName = GetResultNameForDisciplineOverall(selectedDisciplineId, i);
 								var points = GetResultValueForDisciplineOverall(selectedDisciplineId, i);
@@ -113,10 +114,11 @@
                                                                         </div>
                                                                         <div class="award-points">@L["Award Points"]: @awardPoints</div>
 								</div>
-							}
-						</div>
-					}
-				</div>
+                                                        }
+                                                </div>
+                                                }
+                                        </PinchZoomContainer>
+                                </div>
 			</div>
 		}
 

--- a/CompetitionResults/Components/Pages/ResultsListStatic.razor
+++ b/CompetitionResults/Components/Pages/ResultsListStatic.razor
@@ -25,10 +25,11 @@
 						{
                                                         <button @onclick='() => ExportAsPDF("resultContent" + category.Id)' class="m-2">@L["Export to PDF"]</button>
 
-							<div id="resultContent@(category.Id)">
-								<h7 class="mb-1 p-0">@category.Name</h7>
+                                                        <PinchZoomContainer MaxScale="10" Class="mb-3">
+                                                                <div id="resultContent@(category.Id)">
+                                                                        <h7 class="mb-1 p-0">@category.Name</h7>
 
-								<table class="table table-hover table-bordered m-0 p-0 mb-1">
+                                                                        <table class="table table-hover table-bordered m-0 p-0 mb-1">
 									<thead class="thead-light">
 										<tr>
                                                                                         <th style="width: 30px;">@L["Rank"]</th>
@@ -69,8 +70,9 @@
 											</tr>
 										}
 									</tbody>
-								</table>
-							</div>
+                                                                        </table>
+                                                                </div>
+                                                        </PinchZoomContainer>
 						}
 					}
 				</div>
@@ -80,10 +82,11 @@
 				<div class="col-12">
                                         <button @onclick='() => ExportAsPDF("resultContent")' class="m-2">@L["Export to PDF"]</button>
 
-                                        <div id="resultContent">
-                                                <h7 class="mb-1 p-0">@L["Overall"]</h7>
+                                        <PinchZoomContainer MaxScale="10" Class="mb-3">
+                                                <div id="resultContent">
+                                                        <h7 class="mb-1 p-0">@L["Overall"]</h7>
 
-						<table class="table table-hover table-bordered m-0 p-0 mb-1">
+                                                        <table class="table table-hover table-bordered m-0 p-0 mb-1">
 							<thead class="thead-light">
 								<tr>
                                                                         <th style="width: 30px;">@L["Rank"]</th>
@@ -130,8 +133,9 @@
 									</tr>
 								}
 							</tbody>
-						</table>
-					</div>
+                                                        </table>
+                                                </div>
+                                        </PinchZoomContainer>
 				</div>
 			</div>
 
@@ -141,10 +145,11 @@
 				<div class="col-12">
                                         <button @onclick='() => ExportAsPDF("resultContentTwo")' class="m-2">@L["Export to PDF"]</button>
 
-                                        <div id="resultContentTwo">
-                                                <h7 class="mb-1 p-0">@L["Overall 2"]</h7>
+                                        <PinchZoomContainer MaxScale="10" Class="mb-3">
+                                                <div id="resultContentTwo">
+                                                        <h7 class="mb-1 p-0">@L["Overall 2"]</h7>
 
-						<table class="table table-hover table-bordered m-0 p-0 mb-1">
+                                                        <table class="table table-hover table-bordered m-0 p-0 mb-1">
 							<thead class="thead-light">
 								<tr>
                                                                         <th style="width: 30px;">@L["Rank"]</th>
@@ -184,8 +189,9 @@
 									</tr>
 								}
 							</tbody>
-						</table>
-					</div>
+                                                        </table>
+                                                </div>
+                                        </PinchZoomContainer>
 				</div>
 			</div>
 			}

--- a/CompetitionResults/Components/Pages/ResultsSelectable.razor
+++ b/CompetitionResults/Components/Pages/ResultsSelectable.razor
@@ -56,7 +56,7 @@
 				{
 					var allColumns = selectedGroupedDisciplines.Cast<object>().Concat(selectedOverallDisciplines.Cast<object>()).ToList();
 
-					<div class="table-responsive">
+                                        <PinchZoomContainer MaxScale="10" ContentClass="table-responsive">
                                                 <table class="table table-hover table-bordered m-0 p-0">
                                                         <thead class="thead-light">
                                                                 <tr>
@@ -124,8 +124,8 @@
 									</tr>
 								}
 							</tbody>
-						</table>
-					</div>
+                                                </table>
+                                        </PinchZoomContainer>
 				}
 			</div>
 		}

--- a/CompetitionResults/Components/Shared/PinchZoomContainer.razor
+++ b/CompetitionResults/Components/Shared/PinchZoomContainer.razor
@@ -1,0 +1,68 @@
+@using Microsoft.JSInterop
+@implements IAsyncDisposable
+
+<div @ref="_root" class="@ContainerClass" @attributes="AdditionalAttributes">
+    <div class="@ContentClassName" data-pinch-zoom-content>
+        @ChildContent
+    </div>
+</div>
+
+@code {
+    private ElementReference _root;
+    private bool _isInitialized;
+
+    [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
+
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public string? Class { get; set; }
+    [Parameter] public string? ContentClass { get; set; }
+    [Parameter] public double MinScale { get; set; } = 1d;
+    [Parameter] public double MaxScale { get; set; } = 8d;
+    [Parameter] public double InitialScale { get; set; } = 1d;
+    [Parameter] public bool EnableWheelZoom { get; set; } = true;
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string ContainerClass => string.IsNullOrWhiteSpace(Class)
+        ? "pinch-zoom-container"
+        : $"pinch-zoom-container {Class}";
+
+    private string ContentClassName => string.IsNullOrWhiteSpace(ContentClass)
+        ? "pinch-zoom-container__content"
+        : $"pinch-zoom-container__content {ContentClass}";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var minScale = Math.Max(0.1, MinScale);
+            var maxScale = Math.Max(minScale, MaxScale);
+            var initialScale = Math.Clamp(InitialScale, minScale, maxScale);
+
+            var options = new
+            {
+                minScale,
+                maxScale,
+                initialScale,
+                enableWheel = EnableWheelZoom
+            };
+
+            await JSRuntime.InvokeVoidAsync("pinchZoomContainer.init", _root, options);
+            _isInitialized = true;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_isInitialized)
+        {
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("pinchZoomContainer.dispose", _root);
+            }
+            catch (JSDisconnectedException)
+            {
+                // Blazor Server disconnect - safe to ignore
+            }
+        }
+    }
+}

--- a/CompetitionResults/Components/Shared/PinchZoomContainer.razor.css
+++ b/CompetitionResults/Components/Shared/PinchZoomContainer.razor.css
@@ -1,0 +1,19 @@
+.pinch-zoom-container {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    touch-action: none;
+}
+
+.pinch-zoom-container__content {
+    transform-origin: 0 0;
+    user-select: none;
+}
+
+.pinch-zoom-container--zoomed .pinch-zoom-container__content {
+    cursor: grab;
+}
+
+.pinch-zoom-container--zoomed .pinch-zoom-container__content:active {
+    cursor: grabbing;
+}

--- a/CompetitionResults/Components/_Imports.razor
+++ b/CompetitionResults/Components/_Imports.razor
@@ -9,4 +9,5 @@
 @using Microsoft.JSInterop
 @using CompetitionResults
 @using CompetitionResults.Components
+@using CompetitionResults.Components.Shared
 @using Microsoft.Extensions.Localization

--- a/CompetitionResults/wwwroot/js/site.js
+++ b/CompetitionResults/wwwroot/js/site.js
@@ -31,6 +31,33 @@ function generatePDF(htmlId) {
         return;
     }
 
+    const pinchTransforms = [];
+    let ancestor = element;
+    while (ancestor) {
+        if (ancestor.hasAttribute && ancestor.hasAttribute('data-pinch-zoom-content')) {
+            pinchTransforms.push({
+                element: ancestor,
+                transform: ancestor.style.transform,
+                transition: ancestor.style.transition
+            });
+            ancestor.style.transition = 'none';
+            ancestor.style.transform = 'none';
+        }
+        ancestor = ancestor.parentElement;
+    }
+
+    const restoreTransforms = () => {
+        while (pinchTransforms.length > 0) {
+            const entry = pinchTransforms.pop();
+            if (!entry || !entry.element) {
+                continue;
+            }
+
+            entry.element.style.transform = entry.transform || '';
+            entry.element.style.transition = entry.transition || '';
+        }
+    };
+
     const canvasOptions = {
         scale: 3,
         useCORS: true,
@@ -70,7 +97,7 @@ function generatePDF(htmlId) {
         pdf.save("download.pdf");
     }).catch(error => {
         console.error("html2canvas failed:", error);
-    });
+    }).finally(restoreTransforms);
 }
 
 window.scoresList = window.scoresList || {};
@@ -109,4 +136,139 @@ window.throwersList.setSortPreference = function (cookieName, value, days) {
     window.scoresList.setSortPreference(cookieName, value, days);
 };
 
+
+(function () {
+    const instances = new WeakMap();
+    const ZOOM_THRESHOLD = 1.01;
+
+    function ensurePanzoomAvailable() {
+        if (typeof Panzoom === 'function') {
+            return true;
+        }
+
+        console.warn('pinchZoomContainer: Panzoom library is not available.');
+        return false;
+    }
+
+    function updateZoomClass(element, panzoom) {
+        if (!panzoom) {
+            return;
+        }
+
+        const scale = typeof panzoom.getScale === 'function' ? panzoom.getScale() : 1;
+        if (scale > ZOOM_THRESHOLD) {
+            element.classList.add('pinch-zoom-container--zoomed');
+        } else {
+            element.classList.remove('pinch-zoom-container--zoomed');
+        }
+    }
+
+    function cleanup(element) {
+        const entry = instances.get(element);
+        if (!entry) {
+            return;
+        }
+
+        if (entry.wheelListener) {
+            element.removeEventListener('wheel', entry.wheelListener);
+        }
+
+        if (entry.changeListener && entry.content) {
+            entry.content.removeEventListener('panzoomchange', entry.changeListener);
+        }
+
+        entry.panzoom.destroy();
+        instances.delete(element);
+        element.classList.remove('pinch-zoom-container--zoomed');
+    }
+
+    window.pinchZoomContainer = window.pinchZoomContainer || {};
+
+    window.pinchZoomContainer.init = function (element, options) {
+        if (!element || !ensurePanzoomAvailable()) {
+            return;
+        }
+
+        const content = element.querySelector('[data-pinch-zoom-content]');
+        if (!content) {
+            console.warn('pinchZoomContainer: Zoomable content element not found.');
+            return;
+        }
+
+        cleanup(element);
+
+        const settings = Object.assign({
+            minScale: 1,
+            maxScale: 8,
+            initialScale: 1,
+            enableWheel: true
+        }, options || {});
+
+        const minScale = Math.max(0.1, Number(settings.minScale) || 1);
+        const maxScale = Math.max(minScale, Number(settings.maxScale) || minScale);
+        const initialScale = Math.min(Math.max(Number(settings.initialScale) || minScale, minScale), maxScale);
+        const enableWheel = settings.enableWheel !== false;
+
+        if (!content.style.transformOrigin) {
+            content.style.transformOrigin = '0 0';
+        }
+        content.style.willChange = 'transform';
+
+        const panzoom = Panzoom(content, {
+            minScale,
+            maxScale,
+            startScale: initialScale,
+            contain: 'outside',
+            panOnlyWhenZoomed: true
+        });
+
+        const entry = {
+            panzoom,
+            content,
+            initialScale
+        };
+
+        if (enableWheel) {
+            const wheelListener = function (event) {
+                if (!event.ctrlKey) {
+                    return;
+                }
+
+                event.preventDefault();
+                panzoom.zoomWithWheel(event);
+            };
+            element.addEventListener('wheel', wheelListener, { passive: false });
+            entry.wheelListener = wheelListener;
+        }
+
+        const changeListener = function () {
+            updateZoomClass(element, panzoom);
+        };
+        content.addEventListener('panzoomchange', changeListener);
+        entry.changeListener = changeListener;
+
+        updateZoomClass(element, panzoom);
+
+        instances.set(element, entry);
+    };
+
+    window.pinchZoomContainer.reset = function (element) {
+        const entry = instances.get(element);
+        if (!entry) {
+            return;
+        }
+
+        entry.panzoom.zoom(entry.initialScale, { animate: false });
+        entry.panzoom.pan(0, 0, { animate: false });
+        updateZoomClass(element, entry.panzoom);
+    };
+
+    window.pinchZoomContainer.dispose = function (element) {
+        if (!element) {
+            return;
+        }
+
+        cleanup(element);
+    };
+})();
 


### PR DESCRIPTION
## Summary
- add a reusable `PinchZoomContainer` component that wires Panzoom.js for multi-touch zooming
- wrap the results pages in the zoom container and guard PDF export against active transforms
- load the Panzoom script globally and add component-specific styling

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e50828ccdc832c869588924736b81c